### PR TITLE
Harden proxy and repair data provider wiring

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-30T22:13:22.725Z for PR creation at branch issue-63-f635014aaefc for issue https://github.com/suenot/profitmaker/issues/63

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-30T22:13:22.725Z for PR creation at branch issue-63-f635014aaefc for issue https://github.com/suenot/profitmaker/issues/63

--- a/packages/client/src/components/TestServerProvider.tsx
+++ b/packages/client/src/components/TestServerProvider.tsx
@@ -186,7 +186,7 @@ Low: $${parseFloat(ticker.l[1]).toLocaleString()}
         name: 'Test Server',
         type: 'ccxt-server',
         exchanges: ['kraken'],
-        status: 'active',
+        status: 'connected',
         priority: 1,
         config: {
           serverUrl,

--- a/packages/client/src/components/widgets/MarketDataWidget.tsx
+++ b/packages/client/src/components/widgets/MarketDataWidget.tsx
@@ -7,11 +7,11 @@ import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { useCandles, useTrades, useOrderBook, useDataProviders } from '../../hooks/useDataProvider';
 import { formatTimestamp, formatPrice, formatVolume } from '../../utils/formatters';
-import { 
-  TrendingUp, 
-  TrendingDown, 
-  Activity, 
-  Clock, 
+import {
+  TrendingUp,
+  TrendingDown,
+  Activity,
+  Clock,
   Wifi,
   WifiOff,
   BarChart3,
@@ -46,32 +46,35 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
 
   // Data subscriptions
   const candles = useCandles(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-candles`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-candles`,
+    showCandles
   );
 
   const trades = useTrades(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-trades`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-trades`,
+    showTrades
   );
 
   const orderbook = useOrderBook(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-orderbook`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-orderbook`,
+    showOrderBook
   );
 
   // Get last candle for price display
-  const lastCandle = candles.data && candles.data.length > 0 
-    ? candles.data[candles.data.length - 1] 
+  const lastCandle = candles.data && candles.data.length > 0
+    ? candles.data[candles.data.length - 1]
     : null;
 
   const priceChange = lastCandle && candles.data && candles.data.length > 1
@@ -94,7 +97,7 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
     const anyConnected = (showCandles && candles.isSubscribed) ||
                         (showTrades && trades.isSubscribed) ||
                         (showOrderBook && orderbook.isSubscribed);
-    
+
     const anyLoading = (showCandles && candles.loading) ||
                       (showTrades && trades.loading) ||
                       (showOrderBook && orderbook.loading);
@@ -188,7 +191,7 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
                     </span>
                   </div>
                 </div>
-                
+
                 <div className="grid grid-cols-4 gap-4 text-sm">
                   <div>
                     <p className="text-muted-foreground">Open</p>
@@ -309,8 +312,8 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
                 {recentTrades.map((trade, index) => (
                   <div key={trade.id || index} className="flex justify-between items-center py-1 text-sm">
                     <div className="flex items-center gap-2">
-                      <Badge 
-                        variant={trade.side === 'buy' ? 'default' : 'destructive'} 
+                      <Badge
+                        variant={trade.side === 'buy' ? 'default' : 'destructive'}
                         className="text-xs px-1 py-0"
                       >
                         {trade.side}
@@ -341,4 +344,4 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
       )}
     </div>
   );
-}; 
+};

--- a/packages/client/src/components/widgets/UserTradesTab.tsx
+++ b/packages/client/src/components/widgets/UserTradesTab.tsx
@@ -32,64 +32,77 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   accounts,
   settings
 }) => {
-  const [trades, setTrades] = useState<Array<Trade & { 
+  const [trades, setTrades] = useState<Array<Trade & {
     accountId: string;
     exchange: string;
     email: string;
   }>>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Data provider integration - get methods only
   const dataProvider = useDataProviderStore();
 
   // Load trades for accounts
   const loadTrades = useCallback(async () => {
     if (!accounts.length) return;
-    
+
     setLoading(true);
     setError(null);
-    
+
     try {
       console.log(`📊 Loading trades for ${accounts.length} account(s)`);
-      
+
       const allTrades: (Trade & { accountId: string; exchange: string; email: string; })[] = [];
-      
+
       // Load trades from each account
       for (const account of accounts) {
         try {
           console.log(`🔄 Fetching trades for account ${account.id} (${account.exchange})`);
-          
+
           const trades = await dataProvider.fetchMyTrades(
             account.id,
             undefined, // symbol - get all symbols
             undefined, // since - get recent trades
             settings.tradesLimit
           );
-          
+
           // Transform and add account info
-          const tradesWithAccount = trades.map(trade => ({
-            ...trade,
-            accountId: account.id,
-            exchange: account.exchange || 'Unknown',
-            email: account.email || 'Unknown'
-          }));
-          
+          const tradesWithAccount = trades.map(trade => {
+            const rawTrade = trade as Partial<Trade> & typeof trade;
+
+            return {
+              id: trade.id,
+              timestamp: trade.timestamp,
+              symbol: rawTrade.symbol || 'Unknown',
+              side: trade.side,
+              amount: trade.amount,
+              price: trade.price,
+              cost: typeof rawTrade.cost === 'number' ? rawTrade.cost : trade.price * trade.amount,
+              fee: rawTrade.fee,
+              order: rawTrade.order,
+              info: rawTrade.info,
+              accountId: account.id,
+              exchange: account.exchange || 'Unknown',
+              email: account.email || 'Unknown'
+            };
+          });
+
           allTrades.push(...tradesWithAccount);
-          
+
           console.log(`✅ Loaded ${trades.length} trades for account ${account.id}`);
         } catch (error) {
           console.error(`❌ Failed to load trades for account ${account.id}:`, error);
           // Continue with other accounts even if one fails
         }
       }
-      
+
       // Sort trades by timestamp (newest first)
       allTrades.sort((a, b) => b.timestamp - a.timestamp);
-      
+
       setTrades(allTrades);
       console.log(`✅ Total trades loaded: ${allTrades.length}`);
-      
+
     } catch (error) {
       console.error('❌ Failed to load trades:', error);
       setError(error instanceof Error ? error.message : 'Failed to load trades');
@@ -109,13 +122,13 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   // Format currency value
   const formatCurrency = useCallback((value: number, currency?: string) => {
     if (value === 0) return '0';
-    
+
     if (value < 0.001) {
       return value.toFixed(8);
     } else if (value < 1) {
       return value.toFixed(6);
     } else if (value < 1000) {
-      return value.toFixed(4);  
+      return value.toFixed(4);
     } else {
       return value.toFixed(2);
     }
@@ -135,10 +148,10 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
     overscan: 5,
   });
 
-  const renderTradeRow = useCallback((trade: Trade & { 
-    accountId: string; 
-    exchange: string; 
-    email: string; 
+  const renderTradeRow = useCallback((trade: Trade & {
+    accountId: string;
+    exchange: string;
+    email: string;
   }, index: number, style?: React.CSSProperties) => (
     <div
       key={trade.id}
@@ -162,33 +175,33 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
       <div className="text-center min-w-0 flex-1">
         <div className="font-medium text-terminal-text">{trade.symbol}</div>
         <div className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${
-          trade.side === 'buy' 
-            ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200' 
+          trade.side === 'buy'
+            ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200'
             : 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200'
         }`}>
           {trade.side === 'buy' ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
           {trade.side.toUpperCase()}
         </div>
       </div>
-      
+
       {/* Amount */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">{formatCurrency(trade.amount)}</div>
         <div className="text-xs text-terminal-muted">Amount</div>
       </div>
-      
+
       {/* Price */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">{formatCurrency(trade.price)}</div>
         <div className="text-xs text-terminal-muted">Price</div>
       </div>
-      
+
       {/* Cost */}
       <div className="text-right min-w-0 flex-1">
         <div className="font-medium text-terminal-text">{formatCurrency(trade.cost)}</div>
         <div className="text-xs text-terminal-muted">Total</div>
       </div>
-      
+
       {/* Fee */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">
@@ -218,7 +231,7 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
         <div className="text-center">
           <TrendingDown className="w-8 h-8 text-red-500 mb-2 mx-auto" />
           <p className="text-red-500">Error: {error}</p>
-          <button 
+          <button
             onClick={loadTrades}
             className="mt-2 px-3 py-1 bg-terminal-accent/20 hover:bg-terminal-accent/30 rounded text-xs"
           >
@@ -280,7 +293,7 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
         ) : (
           // Render normally for smaller lists
           <div className="overflow-auto">
-            {trades.map((trade, index) => 
+            {trades.map((trade, index) =>
               renderTradeRow(trade, index)
             )}
           </div>
@@ -290,4 +303,4 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   );
 };
 
-export default UserTradesTab; 
+export default UserTradesTab;

--- a/packages/client/src/components/widgets/UserTradesTab.tsx
+++ b/packages/client/src/components/widgets/UserTradesTab.tsx
@@ -45,7 +45,12 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
 
   // Load trades for accounts
   const loadTrades = useCallback(async () => {
-    if (!accounts.length) return;
+    if (!accounts.length) {
+      setTrades([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/packages/client/src/context/WidgetContext.tsx
+++ b/packages/client/src/context/WidgetContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { toast } from "sonner";
 
-export type WidgetType = 'chart' | 'portfolio' | 'orderForm' | 'transactions' | 'watchlist' | 'news' | 'calendar' | 'positions' | 'orderbook' | 'orderbookV2' | 'trades' | 'tradesV2' | 'dataProviderSettings' | 'dataProviderDemo' | 'dataProviderSetup' | 'dataProviderDebug' | 'userBalances';
+export type WidgetType = 'chart' | 'portfolio' | 'orderForm' | 'transactions' | 'watchlist' | 'news' | 'calendar' | 'positions' | 'orderbook' | 'orderbookV2' | 'trades' | 'tradesV2' | 'dataProviderSettings' | 'dataProviderDemo' | 'dataProviderSetup' | 'dataProviderDebug' | 'userBalances' | 'userTradingData';
 
 export interface WidgetGroup {
   id: string;
@@ -59,7 +59,8 @@ const defaultWidgetSizes: Record<WidgetType, { width: number; height: number }> 
   dataProviderDemo: { width: 700, height: 400 },
   dataProviderSetup: { width: 500, height: 400 },
   dataProviderDebug: { width: 700, height: 500 },
-  userBalances: { width: 700, height: 600 }
+  userBalances: { width: 700, height: 600 },
+  userTradingData: { width: 700, height: 600 }
 };
 
 const widgetTitles: Record<WidgetType, string> = {
@@ -444,4 +445,3 @@ export const useWidget = () => {
   }
   return context;
 };
-

--- a/packages/client/src/hooks/useDataProvider.ts
+++ b/packages/client/src/hooks/useDataProvider.ts
@@ -1,18 +1,19 @@
 import { useEffect, useCallback, useMemo } from 'react';
 import { useDataProviderStore } from '../store/dataProviderStore';
-import { 
-  DataType, 
-  Candle, 
-  Trade, 
-  OrderBook, 
-  CreateSubscriptionParams,
-  DataState
+import {
+  DataType,
+  Timeframe,
+  MarketType,
+  ProviderOperationResult
 } from '../types/dataProviders';
+
+const DEFAULT_TIMEFRAME: Timeframe = '1m';
+const DEFAULT_MARKET: MarketType = 'spot';
 
 // NEW: Hook for provider-exchange mappings
 export const useProviderMappings = (exchanges: string[]) => {
   const { getProviderExchangeMappings } = useDataProviderStore();
-  
+
   return useMemo(() => {
     return getProviderExchangeMappings(exchanges);
   }, [exchanges, getProviderExchangeMappings]);
@@ -21,7 +22,7 @@ export const useProviderMappings = (exchanges: string[]) => {
 // NEW: Hook for getting provider for specific exchange
 export const useProviderForExchange = (exchange: string) => {
   const { getProviderForExchange } = useDataProviderStore();
-  
+
   return useMemo(() => {
     return getProviderForExchange(exchange);
   }, [exchange, getProviderForExchange]);
@@ -33,67 +34,68 @@ export const useCandles = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getCandles,
+    getSubscriptionKey,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const candleData = data.candles[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const candleData = getCandles(exchange, symbol, DEFAULT_TIMEFRAME, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-candles-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-candles-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    try {
-      const params: CreateSubscriptionParams = {
-        symbol,
-        dataType: 'candles',
-        exchange,
-        dashboardId,
-        widgetId,
-        providerId: actualProviderId
-      };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-      return await createSubscription(params);
+    try {
+      return await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'candles',
+        DEFAULT_TIMEFRAME,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
     } catch (error) {
       console.error('🛡️ Safe error handling for candles subscription:', error);
       return { success: false, error: `Subscription error: ${error}` };
     }
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   // Automatic subscription/unsubscription
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: candleData?.data || null,
-    loading: candleData?.loading || false,
-    error: candleData?.error || null,
-    lastUpdate: candleData?.lastUpdate || 0,
+    data: candleData.length > 0 ? candleData : null,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!candleData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -103,61 +105,62 @@ export const useTrades = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getSubscriptionKey,
+    getTrades,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const tradeData = data.trades[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const tradeData = getTrades(exchange, symbol, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-trades-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-trades-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    const params: CreateSubscriptionParams = {
-      symbol,
-      dataType: 'trades',
-      exchange,
-      dashboardId,
-      widgetId,
-      providerId: actualProviderId
-    };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-    return await createSubscription(params);
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+    return await subscribeToData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'trades',
+      undefined,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: tradeData?.data || null,
-    loading: tradeData?.loading || false,
-    error: tradeData?.error || null,
-    lastUpdate: tradeData?.lastUpdate || 0,
+    data: tradeData.length > 0 ? tradeData : null,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!tradeData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -167,61 +170,62 @@ export const useOrderBook = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getOrderBook,
+    getSubscriptionKey,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const orderBookData = data.orderbook[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const orderBookData = getOrderBook(exchange, symbol, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-orderbook-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-orderbook-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    const params: CreateSubscriptionParams = {
-      symbol,
-      dataType: 'orderbook',
-      exchange,
-      dashboardId,
-      widgetId,
-      providerId: actualProviderId
-    };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-    return await createSubscription(params);
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+    return await subscribeToData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'orderbook',
+      undefined,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: orderBookData?.data || null,
-    loading: orderBookData?.loading || false,
-    error: orderBookData?.error || null,
-    lastUpdate: orderBookData?.lastUpdate || 0,
+    data: orderBookData,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!orderBookData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -235,27 +239,30 @@ export const useMarketData = (
   widgetId: string = 'default'
 ) => {
   const candles = useCandles(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('candles') ? `${widgetId}-candles` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-candles`,
+    dataTypes.includes('candles')
   );
-  
+
   const trades = useTrades(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('trades') ? `${widgetId}-trades` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-trades`,
+    dataTypes.includes('trades')
   );
-  
+
   const orderbook = useOrderBook(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('orderbook') ? `${widgetId}-orderbook` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-orderbook`,
+    dataTypes.includes('orderbook')
   );
 
   const loading = (dataTypes.includes('candles') && candles.loading) ||
@@ -288,7 +295,6 @@ export const useDataProviders = () => {
     setActiveProvider,
     addProvider,
     removeProvider,
-    initializeProvider,
     loading
   } = useDataProviderStore();
 
@@ -302,7 +308,6 @@ export const useDataProviders = () => {
     setActiveProvider,
     addProvider,
     removeProvider,
-    initializeProvider,
     loading
   };
 };
@@ -310,43 +315,42 @@ export const useDataProviders = () => {
 // Hook for getting connection information
 export const useConnectionStats = () => {
   const {
-    connectionStats,
-    connections,
-    subscriptions,
-    getActiveSubscriptions,
-    closeConnection
+    activeSubscriptions,
+    forceCloseSubscription
   } = useDataProviderStore();
 
   const stats = useMemo(() => {
-    const connectionList = Object.values(connectionStats);
-    const subscriptionList = getActiveSubscriptions();
-    
+    const subscriptionList = Object.entries(activeSubscriptions).map(([id, subscription]) => ({
+      id,
+      ...subscription
+    }));
+
     return {
-      total: connectionList.length,
-      connected: connectionList.filter(c => c.status === 'connected').length,
-      connecting: connectionList.filter(c => c.status === 'connecting').length,
-      error: connectionList.filter(c => c.status === 'error').length,
-      disconnected: connectionList.filter(c => c.status === 'disconnected').length,
+      total: subscriptionList.length,
+      connected: subscriptionList.filter(s => s.isActive && !s.isFallback).length,
+      connecting: subscriptionList.filter(s => s.isActive && s.lastUpdate === 0).length,
+      error: 0,
+      disconnected: subscriptionList.filter(s => !s.isActive).length,
       totalSubscriptions: subscriptionList.length,
-      connections: connectionList,
+      connections: subscriptionList,
       subscriptions: subscriptionList
     };
-  }, [connectionStats, getActiveSubscriptions]);
+  }, [activeSubscriptions]);
 
   return {
     ...stats,
-    closeConnection
+    closeConnection: forceCloseSubscription
   };
 };
 
 // Hook for checking exchange availability
 export const useExchangeSupport = (exchangeId: string) => {
   const { providers } = useDataProviderStore();
-  
+
   return useMemo(() => {
     const supportingProviders = Object.values(providers).filter(provider => {
       if (provider.type === 'ccxt-browser' || provider.type === 'ccxt-server') {
-        return provider.config.exchangeId === exchangeId;
+        return provider.exchanges.includes('*') || provider.exchanges.includes(exchangeId);
       }
       return false;
     });
@@ -357,4 +361,4 @@ export const useExchangeSupport = (exchangeId: string) => {
       count: supportingProviders.length
     };
   }, [providers, exchangeId]);
-}; 
+};

--- a/packages/client/src/hooks/useDataProvider.ts
+++ b/packages/client/src/hooks/useDataProvider.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useState } from 'react';
 import { useDataProviderStore } from '../store/dataProviderStore';
 import {
   DataType,
@@ -47,7 +47,8 @@ export const useCandles = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const candleData = getCandles(exchange, symbol, DEFAULT_TIMEFRAME, DEFAULT_MARKET);
 
@@ -57,10 +58,13 @@ export const useCandles = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
     try {
-      return await subscribeToData(
+      const result = await subscribeToData(
         subscriptionId,
         exchange,
         symbol,
@@ -69,29 +73,46 @@ export const useCandles = (
         DEFAULT_MARKET,
         actualProviderId ? { providerId: actualProviderId } : undefined
       );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
     } catch (error) {
       console.error('🛡️ Safe error handling for candles subscription:', error);
-      return { success: false, error: `Subscription error: ${error}` };
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
     }
   }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
+    setLastError(null);
     if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+    unsubscribeFromData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'candles',
+      DEFAULT_TIMEFRAME,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   // Automatic subscription/unsubscription
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: candleData.length > 0 ? candleData : null,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -118,7 +139,8 @@ export const useTrades = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const tradeData = getTrades(exchange, symbol, DEFAULT_MARKET);
 
@@ -128,9 +150,34 @@ export const useTrades = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
-    return await subscribeToData(
+    try {
+      const result = await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'trades',
+        undefined,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
+    } catch (error) {
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
+    }
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
+
+  const unsubscribe = useCallback(() => {
+    setLastError(null);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(
       subscriptionId,
       exchange,
       symbol,
@@ -139,24 +186,23 @@ export const useTrades = (
       DEFAULT_MARKET,
       actualProviderId ? { providerId: actualProviderId } : undefined
     );
-  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
-
-  const unsubscribe = useCallback(() => {
-    if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: tradeData.length > 0 ? tradeData : null,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -183,7 +229,8 @@ export const useOrderBook = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const orderBookData = getOrderBook(exchange, symbol, DEFAULT_MARKET);
 
@@ -193,9 +240,34 @@ export const useOrderBook = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
-    return await subscribeToData(
+    try {
+      const result = await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'orderbook',
+        undefined,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
+    } catch (error) {
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
+    }
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
+
+  const unsubscribe = useCallback(() => {
+    setLastError(null);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(
       subscriptionId,
       exchange,
       symbol,
@@ -204,24 +276,23 @@ export const useOrderBook = (
       DEFAULT_MARKET,
       actualProviderId ? { providerId: actualProviderId } : undefined
     );
-  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
-
-  const unsubscribe = useCallback(() => {
-    if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: orderBookData,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -327,7 +398,7 @@ export const useConnectionStats = () => {
 
     return {
       total: subscriptionList.length,
-      connected: subscriptionList.filter(s => s.isActive && !s.isFallback).length,
+      connected: subscriptionList.filter(s => s.isActive && !s.isFallback && s.lastUpdate !== 0).length,
       connecting: subscriptionList.filter(s => s.isActive && s.lastUpdate === 0).length,
       error: 0,
       disconnected: subscriptionList.filter(s => !s.isActive).length,

--- a/packages/client/src/store/actions/ccxtActions.ts
+++ b/packages/client/src/store/actions/ccxtActions.ts
@@ -16,7 +16,7 @@ export const createCCXTActions: StateCreator<
   // Intelligent CCXT method selection
   selectOptimalOrderBookMethod: (exchange: string, exchangeInstance: any): OrderBookMethodSelection => {
     console.log(`🔍 Analyzing ${exchange} capabilities to select optimal orderbook method...`);
-    
+
     // Check available exchange capabilities
     const capabilities: CCXTMethodCapabilities = {
       watchOrderBookForSymbols: !!exchangeInstance.has?.['watchOrderBookForSymbols'],
@@ -68,10 +68,12 @@ export const createCCXTActions: StateCreator<
       state.marketData = {
         candles: {},
         trades: {},
-        orderbook: {}
+        orderbook: {},
+        balance: {},
+        ticker: {}
       };
     });
 
     console.log(`🧹 Data provider store cleaned up`);
   }
-}); 
+});

--- a/packages/client/src/store/actions/dataActions.ts
+++ b/packages/client/src/store/actions/dataActions.ts
@@ -69,8 +69,30 @@ export interface DataActions {
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
   
   // Utilities
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, providerId?: string) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
+}
+
+function updateMatchingSubscriptionTimestamps(
+  activeSubscriptions: Record<string, ActiveSubscription>,
+  exchange: string,
+  symbol: string,
+  dataType: DataType,
+  timeframe: Timeframe | undefined,
+  market: MarketType
+) {
+  const now = Date.now();
+  Object.values(activeSubscriptions).forEach((subscription) => {
+    if (
+      subscription.key.exchange === exchange &&
+      subscription.key.symbol === symbol &&
+      subscription.key.dataType === dataType &&
+      subscription.key.timeframe === timeframe &&
+      subscription.key.market === market
+    ) {
+      subscription.lastUpdate = now;
+    }
+  });
 }
 
 export const createDataActions: StateCreator<
@@ -322,11 +344,7 @@ export const createDataActions: StateCreator<
         console.log(`🔄 [updateCandles] WebSocket update: ${candles.length} new/updated candles, total: ${mergedCandles.length} for ${exchange}:${market}:${symbol}:${timeframe}, event: ${eventType}`);
       }
       
-      // Update last update timestamp
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'candles', timeframe, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'candles', timeframe, market);
     });
 
     // Emit event for Chart widgets after store update
@@ -355,11 +373,7 @@ export const createDataActions: StateCreator<
       const combined = [...existing, ...trades];
       state.marketData.trades[exchange][market][symbol] = combined.slice(-1000); // Keep last 1000
       
-      // Update last update timestamp
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'trades', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'trades', undefined, market);
     });
   },
 
@@ -391,11 +405,7 @@ export const createDataActions: StateCreator<
         allExchanges: Object.keys(state.marketData.orderbook)
       });
       
-      // Update last update timestamp
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'orderbook', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'orderbook', undefined, market);
     });
   },
 
@@ -422,11 +432,7 @@ export const createDataActions: StateCreator<
         allAccounts: Object.keys(state.marketData.balance)
       });
       
-      // Update last update timestamp
-      const subscriptionKey = get().getSubscriptionKey('', accountId, 'balance', undefined, effectiveWalletType as MarketType);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, '', accountId, 'balance', undefined, effectiveWalletType as MarketType);
     });
   },
 
@@ -464,19 +470,18 @@ export const createDataActions: StateCreator<
         allExchanges: Object.keys(state.marketData.ticker)
       });
       
-      // Update last update timestamp for subscription
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'ticker', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'ticker', undefined, market);
     });
   },
 
   // Utilities
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot'): string => {
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', providerId?: string): string => {
     let key = `${exchange}:${market}:${symbol}:${dataType}`;
     if (dataType === 'candles' && timeframe) {
       key += `:${timeframe}`;
+    }
+    if (providerId) {
+      key += `:provider:${providerId}`;
     }
     return key;
   },

--- a/packages/client/src/store/actions/fetchingActions.ts
+++ b/packages/client/src/store/actions/fetchingActions.ts
@@ -131,7 +131,7 @@ export const createFetchingActions: StateCreator<
         exchangeInstance = createExchangeInstance(exchange, provider, ccxtPro);
       }
       
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, provider.id);
 
       // CCXT Pro supports WebSocket by default for all major exchanges
       console.log(`📡 Starting CCXT Pro WebSocket stream: ${exchange} ${symbol} ${dataType}`);
@@ -404,7 +404,7 @@ export const createFetchingActions: StateCreator<
         exchangeInstance = createExchangeInstance(exchange, provider, ccxt);
       }
 
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, provider.id);
       const interval = get().dataFetchSettings.restIntervals[dataType];
 
       console.log(`🔄 Starting REST polling: ${exchange} ${symbol} ${dataType} every ${interval}ms`);
@@ -739,4 +739,4 @@ export const createFetchingActions: StateCreator<
       console.error(`❌ [Balance] Error fetching balance for account ${accountId}:`, error);
     }
   }
-}); 
+});

--- a/packages/client/src/store/actions/subscriptionActions.ts
+++ b/packages/client/src/store/actions/subscriptionActions.ts
@@ -4,8 +4,27 @@ import type { DataType, ProviderOperationResult, Timeframe, MarketType, Subscrip
 
 export interface SubscriptionActions {
   subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: Pick<SubscriptionConfig, 'providerId'>) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
+}
+
+function findSubscriptionKey(
+  activeSubscriptions: DataProviderStore['activeSubscriptions'],
+  exchange: string,
+  symbol: string,
+  dataType: DataType,
+  timeframe: Timeframe | undefined,
+  market: MarketType,
+  providerId?: string
+): string | undefined {
+  return Object.entries(activeSubscriptions).find(([, subscription]) => (
+    subscription.key.exchange === exchange &&
+    subscription.key.symbol === symbol &&
+    subscription.key.dataType === dataType &&
+    subscription.key.timeframe === timeframe &&
+    subscription.key.market === market &&
+    (!providerId || subscription.providerId === providerId)
+  ))?.[0];
 }
 
 export const createSubscriptionActions: StateCreator<
@@ -16,9 +35,10 @@ export const createSubscriptionActions: StateCreator<
 > = (set, get) => ({
   // Deduplicated subscriptions management
   subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: SubscriptionConfig): Promise<ProviderOperationResult> => {
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
     const currentMethod = get().dataFetchSettings.method;
     const { providerId, ...subscriptionConfig } = config ?? {};
+    const effectiveProviderId = providerId ?? get().getProviderForExchange(exchange)?.id;
+    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, effectiveProviderId);
     const hasSubscriptionConfig = Object.keys(subscriptionConfig).length > 0;
 
     try {
@@ -47,7 +67,7 @@ export const createSubscriptionActions: StateCreator<
             isFallback: false, // Initially not fallback
             isActive: false,
             lastUpdate: 0,
-            providerId,
+            providerId: effectiveProviderId,
             config: hasSubscriptionConfig ? subscriptionConfig : undefined
           };
           needsStart = true;
@@ -74,8 +94,16 @@ export const createSubscriptionActions: StateCreator<
     }
   },
 
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot') => {
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: Pick<SubscriptionConfig, 'providerId'>) => {
+    const effectiveProviderId = config?.providerId ?? get().getProviderForExchange(exchange)?.id;
+    const providerSubscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, effectiveProviderId);
+    const legacySubscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+    const activeSubscriptions = get().activeSubscriptions;
+    const subscriptionKey = activeSubscriptions[providerSubscriptionKey]
+      ? providerSubscriptionKey
+      : activeSubscriptions[legacySubscriptionKey]
+        ? legacySubscriptionKey
+        : findSubscriptionKey(activeSubscriptions, exchange, symbol, dataType, timeframe, market, effectiveProviderId) ?? providerSubscriptionKey;
 
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {

--- a/packages/client/src/store/actions/subscriptionActions.ts
+++ b/packages/client/src/store/actions/subscriptionActions.ts
@@ -1,9 +1,9 @@
 import type { StateCreator } from 'zustand';
 import type { DataProviderStore } from '../types';
-import type { DataType, ProviderOperationResult, Timeframe, MarketType } from '../../types/dataProviders';
+import type { DataType, ProviderOperationResult, Timeframe, MarketType, SubscriptionConfig } from '../../types/dataProviders';
 
 export interface SubscriptionActions {
-  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }) => Promise<ProviderOperationResult>;
+  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
 }
@@ -15,21 +15,23 @@ export const createSubscriptionActions: StateCreator<
   SubscriptionActions
 > = (set, get) => ({
   // Deduplicated subscriptions management
-  subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }): Promise<ProviderOperationResult> => {
+  subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: SubscriptionConfig): Promise<ProviderOperationResult> => {
     const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
     const currentMethod = get().dataFetchSettings.method;
-    
+    const { providerId, ...subscriptionConfig } = config ?? {};
+    const hasSubscriptionConfig = Object.keys(subscriptionConfig).length > 0;
+
     try {
       let needsStart = false;
       let needsRestart = false;
-      
+
       set(state => {
         // Look for existing subscription
         if (state.activeSubscriptions[subscriptionKey]) {
           // Increase subscriber count
           state.activeSubscriptions[subscriptionKey].subscriberCount++;
           console.log(`📈 Subscriber ${subscriberId} added to existing subscription: ${subscriptionKey} (count: ${state.activeSubscriptions[subscriptionKey].subscriberCount})`);
-          
+
           // IMPORTANT: Check if subscription method matches current settings
           if (state.activeSubscriptions[subscriptionKey].method !== currentMethod) {
             console.log(`🔄 Subscription ${subscriptionKey} method outdated (${state.activeSubscriptions[subscriptionKey].method} -> ${currentMethod})`);
@@ -45,7 +47,8 @@ export const createSubscriptionActions: StateCreator<
             isFallback: false, // Initially not fallback
             isActive: false,
             lastUpdate: 0,
-            config: config // Add config support
+            providerId,
+            config: hasSubscriptionConfig ? subscriptionConfig : undefined
           };
           needsStart = true;
                       console.log(`🆕 New subscription created: ${subscriptionKey} for subscriber ${subscriberId} (method: ${currentMethod}, config:`, config, ')');
@@ -73,12 +76,12 @@ export const createSubscriptionActions: StateCreator<
 
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot') => {
     const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
-    
+
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {
         state.activeSubscriptions[subscriptionKey].subscriberCount--;
         console.log(`📉 Subscriber ${subscriberId} removed from subscription: ${subscriptionKey} (count: ${state.activeSubscriptions[subscriptionKey].subscriberCount})`);
-        
+
         // If no subscribers left - stop data fetching
         if (state.activeSubscriptions[subscriptionKey].subscriberCount <= 0) {
           get().stopDataFetching(subscriptionKey);
@@ -91,10 +94,10 @@ export const createSubscriptionActions: StateCreator<
 
   forceCloseSubscription: (subscriptionKey: string) => {
     console.log(`🔨 Force closing subscription: ${subscriptionKey}`);
-    
+
     // Stop data fetching immediately
     get().stopDataFetching(subscriptionKey);
-    
+
     // Remove from active subscriptions
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {
@@ -103,4 +106,4 @@ export const createSubscriptionActions: StateCreator<
       }
     });
   }
-}); 
+});

--- a/packages/client/src/store/providers/ccxtServerProvider.test.ts
+++ b/packages/client/src/store/providers/ccxtServerProvider.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+import { deriveSocketUrl } from './ccxtServerProvider';
+
+describe('deriveSocketUrl', () => {
+  test('uses the next port for explicit local server URLs', () => {
+    expect(deriveSocketUrl('http://localhost:3001')).toBe('http://localhost:3002');
+    expect(deriveSocketUrl('http://127.0.0.1:4000/')).toBe('http://127.0.0.1:4001');
+  });
+
+  test('keeps reverse-proxied URLs without explicit ports unchanged', () => {
+    expect(deriveSocketUrl('https://api.profitmaker.cc')).toBe('https://api.profitmaker.cc');
+  });
+
+  test('falls back to trimming invalid URLs', () => {
+    expect(deriveSocketUrl('not-a-url/')).toBe('not-a-url');
+  });
+});

--- a/packages/client/src/store/providers/ccxtServerProvider.ts
+++ b/packages/client/src/store/providers/ccxtServerProvider.ts
@@ -145,6 +145,8 @@ export class CCXTServerProviderImpl {
         // Authenticate
         if (this.token) {
           this.socket!.emit('authenticate', { token: this.token });
+        } else {
+          resolve(this.socket!);
         }
       });
 

--- a/packages/client/src/store/providers/ccxtServerProvider.ts
+++ b/packages/client/src/store/providers/ccxtServerProvider.ts
@@ -13,6 +13,18 @@ interface ServerResponse<T = any> {
   details?: string;
 }
 
+export function deriveSocketUrl(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    if (url.port) {
+      url.port = String(Number(url.port) + 1);
+    }
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return serverUrl.replace(/\/$/, '');
+  }
+}
+
 /**
  * CCXT Server Provider Implementation
  * Взаимодействует с Express сервером для выполнения CCXT операций
@@ -21,6 +33,7 @@ interface ServerResponse<T = any> {
 export class CCXTServerProviderImpl {
   private provider: CCXTServerProvider;
   private baseUrl: string;
+  private socketUrl: string;
   private token?: string;
   private timeout: number;
   private socket?: Socket;
@@ -29,6 +42,7 @@ export class CCXTServerProviderImpl {
   constructor(provider: CCXTServerProvider) {
     this.provider = provider;
     this.baseUrl = provider.config.serverUrl.replace(/\/$/, ''); // Remove trailing slash
+    this.socketUrl = (provider.config.socketUrl || deriveSocketUrl(provider.config.serverUrl)).replace(/\/$/, '');
     this.token = provider.config.token;
     this.timeout = provider.config.timeout || 30000;
   }
@@ -112,9 +126,9 @@ export class CCXTServerProviderImpl {
       return this.socket;
     }
 
-    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.baseUrl}`);
+    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.socketUrl}`);
 
-    this.socket = io(this.baseUrl, {
+    this.socket = io(this.socketUrl, {
       transports: ['websocket'],
       timeout: this.timeout,
     });

--- a/packages/client/src/store/types.ts
+++ b/packages/client/src/store/types.ts
@@ -17,7 +17,8 @@ import type {
   WalletType,
   ChartUpdateListener,
   ChartUpdateEvent,
-  ProviderExchangeMapping
+  ProviderExchangeMapping,
+  SubscriptionConfig
 } from '../types/dataProviders';
 import type { User } from './userStore';
 
@@ -26,16 +27,16 @@ export interface DataProviderState {
   // Data providers
   providers: Record<string, DataProvider>;
   activeProviderId: string | null; // Deprecated, kept for compatibility
-  
+
   // Data fetch settings
   dataFetchSettings: DataFetchSettings;
-  
+
   // Active subscriptions with deduplication
   activeSubscriptions: Record<string, ActiveSubscription>;
-  
+
   // REST cycles
   restCycles: Record<string, RestCycleManager>;
-  
+
   // Centralized data storage
   marketData: {
     candles: Record<string, Record<string, Record<string, Record<string, Candle[]>>>>; // [exchange][market][symbol][timeframe] -> Candle[]
@@ -44,10 +45,10 @@ export interface DataProviderState {
     balance: Record<string, Record<string, ExchangeBalances>>; // [accountId][walletType] -> ExchangeBalances
     ticker: Record<string, Record<string, Record<string, Ticker & { lastUpdate: number }>>>; // [exchange][market][symbol] -> Ticker with cache timestamp
   };
-  
+
   // Event system for notifying Chart widgets
   chartUpdateListeners: Record<string, ChartUpdateListener[]>; // [subscriptionKey] -> [listeners]
-  
+
   // State
   loading: boolean;
   error: string | null;
@@ -59,38 +60,38 @@ export interface DataProviderActions {
   addProvider: (provider: DataProvider) => void;
   removeProvider: (providerId: string) => void;
   setActiveProvider: (providerId: string) => void;
-  
+
   // NEW: Multiple provider management
   enableProvider: (providerId: string) => void;
   disableProvider: (providerId: string) => void;
   toggleProvider: (providerId: string) => void;
   isProviderEnabled: (providerId: string) => boolean;
   getEnabledProviders: () => DataProvider[];
-  
+
   // NEW: Advanced provider management with user integration
   createProvider: (type: 'ccxt-browser' | 'ccxt-server' | 'marketmaker.cc' | 'custom-server-with-adapter', name: string, exchanges: string[], config?: any) => DataProvider;
   updateProvider: (providerId: string, updates: { name?: string; exchanges?: string[]; priority?: number; config?: any }) => void;
   getProviderForExchange: (exchange: string) => DataProvider | null;
   getProviderExchangeMappings: (exchanges: string[]) => ProviderExchangeMapping[];
   updateProviderPriority: (providerId: string, priority: number) => void;
-  
+
   // NEW: Get symbols and markets from provider
   getSymbolsForExchange: (exchange: string, limit?: number, marketType?: string) => Promise<string[]>;
   getMarketsForExchange: (exchange: string) => Promise<string[]>;
   getAllSupportedExchanges: () => string[];
-  
+
   // NEW: Get timeframes from provider
   getTimeframesForExchange: (exchange: string) => Timeframe[];
-  
+
   // Data fetch settings management
   setDataFetchMethod: (method: DataFetchMethod) => Promise<void>;
   setRestInterval: (dataType: DataType, interval: number) => void;
-  
+
   // Deduplicated subscriptions management
-  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }) => Promise<ProviderOperationResult>;
+  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
-  
+
   // Data retrieval from store
   getCandles: (exchange: string, symbol: string, timeframe?: Timeframe, market?: MarketType) => Candle[];
   getTrades: (exchange: string, symbol: string, market?: MarketType) => Trade[];
@@ -98,60 +99,60 @@ export interface DataProviderActions {
   getBalance: (accountId: string, walletType?: WalletType) => ExchangeBalances | null;
   getTicker: (exchange: string, symbol: string, market?: MarketType, maxAge?: number) => Ticker | null;
   getTickerWithRefresh: (exchange: string, symbol: string, market?: MarketType, forceRefresh?: boolean) => Promise<Ticker | null>;
-  
+
   // REST data initialization for Chart widgets
   initializeChartData: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType) => Promise<Candle[]>;
-  
+
   // REST data initialization for Trades widgets
   initializeTradesData: (exchange: string, symbol: string, market: MarketType, limit?: number, aggregated?: boolean) => Promise<Trade[]>;
-  
+
   // REST data initialization for OrderBook widgets
   initializeOrderBookData: (exchange: string, symbol: string, market: MarketType) => Promise<OrderBook>;
-  
+
   // REST data initialization for Balance widgets
   initializeBalanceData: (accountId: string, walletType: WalletType) => Promise<ExchangeBalances>;
-  
+
   // REST data initialization for Ticker widgets
   initializeTickerData: (exchange: string, symbol: string, market: MarketType) => Promise<Ticker>;
-  
+
   // Infinite scroll: Load historical candles before given timestamp
   loadHistoricalCandles: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, beforeTimestamp: number) => Promise<Candle[]>;
-  
+
   // User trading data methods
   fetchMyTrades: (accountId: string, symbol?: string, since?: number, limit?: number) => Promise<Trade[]>;
   fetchOrders: (accountId: string, symbol?: string, since?: number, limit?: number) => Promise<any[]>;
   fetchOpenOrders: (accountId: string, symbol?: string) => Promise<any[]>;
   fetchPositions: (accountId: string, symbols?: string[]) => Promise<any[]>;
-  
+
   // Central store data updates
   updateCandles: (exchange: string, symbol: string, candles: Candle[], timeframe?: Timeframe, market?: MarketType) => void;
   updateTrades: (exchange: string, symbol: string, trades: Trade[], market?: MarketType) => void;
   updateOrderBook: (exchange: string, symbol: string, orderbook: OrderBook, market?: MarketType) => void;
   updateBalance: (accountId: string, balance: ExchangeBalances, walletType?: WalletType) => void;
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
-  
+
   // Utilities
   getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
-  
+
   // Event system for Chart widgets
   addChartUpdateListener: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, listener: ChartUpdateListener) => void;
   removeChartUpdateListener: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, listener: ChartUpdateListener) => void;
   emitChartUpdateEvent: (event: ChartUpdateEvent) => void;
-  
+
   // Internal data flow management functions
   startDataFetching: (subscriptionKey: string) => Promise<void>;
   stopDataFetching: (subscriptionKey: string) => void;
   startWebSocketFetching: (exchange: string, symbol: string, dataType: DataType, provider: DataProvider, timeframe?: Timeframe, market?: MarketType) => Promise<void>;
   startRestFetching: (exchange: string, symbol: string, dataType: DataType, provider: DataProvider, timeframe?: Timeframe, market?: MarketType) => Promise<void>;
   fetchBalance: (accountId: string, walletType?: WalletType) => Promise<void>;
-  
+
   // Intelligent CCXT method selection
   selectOptimalOrderBookMethod: (exchange: string, exchangeInstance: any) => OrderBookMethodSelection;
-  
+
   // Cleanup
   cleanup: () => void;
 }
 
 // Main store type
-export type DataProviderStore = DataProviderState & DataProviderActions; 
+export type DataProviderStore = DataProviderState & DataProviderActions;

--- a/packages/client/src/store/types.ts
+++ b/packages/client/src/store/types.ts
@@ -89,7 +89,7 @@ export interface DataProviderActions {
 
   // Deduplicated subscriptions management
   subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: Pick<SubscriptionConfig, 'providerId'>) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
 
   // Data retrieval from store
@@ -132,7 +132,7 @@ export interface DataProviderActions {
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
 
   // Utilities
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, providerId?: string) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
 
   // Event system for Chart widgets

--- a/packages/client/src/store/utils/webSocketUtils.ts
+++ b/packages/client/src/store/utils/webSocketUtils.ts
@@ -285,7 +285,10 @@ export const createWebSocketManager = (): WebSocketConnectionManager => {
       // Закрываем все активные подписки
       for (const [id, subscription] of subscriptions) {
         if (subscription.isActive) {
-          await this.unsubscribe(id);
+          subscriptions.set(id, {
+            ...subscription,
+            isActive: false
+          });
         }
       }
       

--- a/packages/client/src/types/dataProviders.ts
+++ b/packages/client/src/types/dataProviders.ts
@@ -123,6 +123,7 @@ export interface CCXTBrowserConfig {
 // Configuration for CCXT Server - УПРОЩЕННАЯ ВЕРСИЯ
 export interface CCXTServerConfig {
   serverUrl: string;
+  socketUrl?: string; // Optional Socket.IO URL; defaults to serverUrl port + 1 when a port is present
   token?: string; // Authentication token for server
   timeout?: number;
   sandbox?: boolean;
@@ -255,7 +256,7 @@ export interface DataFetchSettings {
   method: DataFetchMethod;
   restIntervals: {
     trades: number; // milliseconds
-    candles: number; // milliseconds  
+    candles: number; // milliseconds
     orderbook: number; // milliseconds
     balance: number; // milliseconds
     ticker: number; // milliseconds
@@ -270,6 +271,13 @@ export interface SubscriptionKey {
   market?: MarketType; // Тип рынка (spot/futures)
 }
 
+export interface SubscriptionConfig {
+  providerId?: string; // Force a specific provider instead of auto-selection
+  isAggregated?: boolean; // для trades: использовать ли aggregate режим
+  tradesLimit?: number; // для trades: лимит количества
+  [key: string]: any; // дополнительные параметры
+}
+
 export interface ActiveSubscription {
   key: SubscriptionKey;
   subscriberCount: number;
@@ -281,15 +289,11 @@ export interface ActiveSubscription {
   wsConnection?: WebSocket; // для WebSocket соединений
   ccxtMethod?: string; // какой именно CCXT метод используется (watchOrderBook, watchBidsAsks, etc.)
   providerId?: string; // ID провайдера обслуживающего эту подписку
-  config?: {
-    isAggregated?: boolean; // для trades: использовать ли aggregate режим
-    tradesLimit?: number; // для trades: лимит количества
-    [key: string]: any; // дополнительные параметры
-  };
+  config?: SubscriptionConfig;
 }
 
 // CCXT specific types
-export type CCXTOrderBookMethod = 
+export type CCXTOrderBookMethod =
   | 'watchOrderBookForSymbols'  // Приоритет 1: diff обновления
   | 'watchOrderBook'            // Приоритет 2: полные снепшоты
   | 'fetchOrderBook';           // Fallback: REST
@@ -317,7 +321,7 @@ export interface RestCycleManager {
   subscriberIds: Set<string>;
 }
 
-// Event system for Chart widgets  
+// Event system for Chart widgets
 export type ChartUpdateEventType = 'initial_load' | 'new_candles' | 'update_last_candle' | 'full_refresh';
 
 export interface ChartUpdateEvent {
@@ -335,4 +339,4 @@ export interface ChartUpdateEvent {
   timestamp: number;
 }
 
-export type ChartUpdateListener = (event: ChartUpdateEvent) => void; 
+export type ChartUpdateListener = (event: ChartUpdateEvent) => void;

--- a/packages/core/src/ccxtServerProvider.ts
+++ b/packages/core/src/ccxtServerProvider.ts
@@ -13,6 +13,18 @@ interface ServerResponse<T = any> {
   details?: string;
 }
 
+export function deriveSocketUrl(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    if (url.port) {
+      url.port = String(Number(url.port) + 1);
+    }
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return serverUrl.replace(/\/$/, '');
+  }
+}
+
 /**
  * CCXT Server Provider Implementation
  * Взаимодействует с Express сервером для выполнения CCXT операций
@@ -21,6 +33,7 @@ interface ServerResponse<T = any> {
 export class CCXTServerProviderImpl {
   private provider: CCXTServerProvider;
   private baseUrl: string;
+  private socketUrl: string;
   private token?: string;
   private timeout: number;
   private socket?: Socket;
@@ -29,6 +42,7 @@ export class CCXTServerProviderImpl {
   constructor(provider: CCXTServerProvider) {
     this.provider = provider;
     this.baseUrl = provider.config.serverUrl.replace(/\/$/, ''); // Remove trailing slash
+    this.socketUrl = (provider.config.socketUrl || deriveSocketUrl(provider.config.serverUrl)).replace(/\/$/, '');
     this.token = provider.config.token;
     this.timeout = provider.config.timeout || 30000;
   }
@@ -112,9 +126,9 @@ export class CCXTServerProviderImpl {
       return this.socket;
     }
 
-    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.baseUrl}`);
+    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.socketUrl}`);
 
-    this.socket = io(this.baseUrl, {
+    this.socket = io(this.socketUrl, {
       transports: ['websocket'],
       timeout: this.timeout,
     });

--- a/packages/server/src/routes/proxy.test.ts
+++ b/packages/server/src/routes/proxy.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import {
   isBlockedProxyHostname,
+  resolveProxyTarget,
   sanitizeProxyHeaders,
+  validateProxyRequest,
   validateProxyRequestBody,
 } from './proxy';
 
@@ -42,6 +44,32 @@ describe('proxy request validation', () => {
 
     for (const url of blockedUrls) {
       expect(validateProxyRequestBody({ url }).ok).toBe(false);
+    }
+  });
+
+  test('rejects public hostnames that resolve to private addresses', async () => {
+    const resolver = {
+      resolve4: async () => ['127.0.0.1'],
+      resolve6: async () => [],
+    };
+
+    const result = await validateProxyRequest({ url: 'https://attacker.example' }, resolver);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('Proxy URL host is not allowed');
+    }
+  });
+
+  test('pins resolved public addresses for outbound requests', async () => {
+    const target = await resolveProxyTarget('api.example', {
+      resolve4: async () => ['8.8.8.8'],
+      resolve6: async () => ['2001:4860:4860::8888'],
+    });
+
+    expect(target.ok).toBe(true);
+    if (target.ok) {
+      expect(target.address).toBe('8.8.8.8');
+      expect(target.family).toBe(4);
     }
   });
 

--- a/packages/server/src/routes/proxy.test.ts
+++ b/packages/server/src/routes/proxy.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isBlockedProxyHostname,
+  sanitizeProxyHeaders,
+  validateProxyRequestBody,
+} from './proxy';
+
+describe('proxy request validation', () => {
+  test('accepts public http and https URLs', () => {
+    const result = validateProxyRequestBody({
+      url: 'https://api.binance.com/api/v3/time',
+      method: 'post',
+      headers: { Authorization: 'Bearer exchange-token' },
+      body: { ping: true },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.request.method).toBe('POST');
+      expect(result.request.headers.Authorization).toBe('Bearer exchange-token');
+      expect(result.request.timeout).toBe(30_000);
+    }
+  });
+
+  test('rejects unsupported protocols and methods', () => {
+    expect(validateProxyRequestBody({ url: 'file:///etc/passwd' }).ok).toBe(false);
+    expect(validateProxyRequestBody({ url: 'https://api.binance.com', method: 'TRACE' }).ok).toBe(false);
+  });
+
+  test('rejects credentialed and private-network URLs', () => {
+    const blockedUrls = [
+      'https://user:pass@example.com',
+      'http://localhost:3001/health',
+      'http://127.0.0.1:3001/health',
+      'http://10.0.0.5/status',
+      'http://172.16.0.5/status',
+      'http://192.168.1.1/status',
+      'http://169.254.169.254/latest/meta-data',
+      'http://[::1]/health',
+      'http://[::ffff:172.16.0.5]/status',
+    ];
+
+    for (const url of blockedUrls) {
+      expect(validateProxyRequestBody({ url }).ok).toBe(false);
+    }
+  });
+
+  test('detects blocked hostnames directly', () => {
+    expect(isBlockedProxyHostname('localhost')).toBe(true);
+    expect(isBlockedProxyHostname('service.localhost')).toBe(true);
+    expect(isBlockedProxyHostname('metadata.google.internal')).toBe(true);
+    expect(isBlockedProxyHostname('::ffff:7f00:1')).toBe(true);
+    expect(isBlockedProxyHostname('api.binance.com')).toBe(false);
+    expect(isBlockedProxyHostname('::ffff:808:808')).toBe(false);
+  });
+
+  test('sanitizes hop-by-hop headers without removing exchange auth headers', () => {
+    const headers = sanitizeProxyHeaders({
+      Host: 'evil.local',
+      Connection: 'keep-alive',
+      'Content-Length': 10,
+      'Sec-Fetch-Site': 'same-origin',
+      Authorization: 'Bearer token',
+      'X-Exchange-Signature': 'signed',
+    });
+
+    expect(headers).toEqual({
+      Authorization: 'Bearer token',
+      'X-Exchange-Signature': 'signed',
+    });
+  });
+
+  test('clamps timeout to the supported range', () => {
+    const result = validateProxyRequestBody({
+      url: 'https://api.binance.com',
+      timeout: 500_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.request.timeout).toBe(60_000);
+  });
+});

--- a/packages/server/src/routes/proxy.ts
+++ b/packages/server/src/routes/proxy.ts
@@ -1,4 +1,9 @@
 import { Elysia } from 'elysia';
+import { resolve4, resolve6 } from 'node:dns/promises';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { isIP } from 'node:net';
+import type { RequestOptions } from 'node:http';
 
 const DEFAULT_PROXY_TIMEOUT_MS = 30_000;
 const MIN_PROXY_TIMEOUT_MS = 1_000;
@@ -28,6 +33,8 @@ type ProxyValidationResult =
         headers: Record<string, string>;
         body: unknown;
         timeout: number;
+        targetAddress?: string;
+        targetFamily?: 4 | 6;
       };
     }
   | {
@@ -37,8 +44,35 @@ type ProxyValidationResult =
       details?: string;
     };
 
+type ProxyResolver = {
+  resolve4: (hostname: string) => Promise<string[]>;
+  resolve6: (hostname: string) => Promise<string[]>;
+};
+
+type ProxyResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  text: string;
+};
+
+const defaultResolver: ProxyResolver = {
+  resolve4,
+  resolve6,
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/\.$/, '');
 }
 
 function parseIPv4Address(hostname: string): number[] | null {
@@ -107,12 +141,7 @@ function isBlockedIPv6(hostname: string): boolean {
 }
 
 export function isBlockedProxyHostname(hostname: string): boolean {
-  const normalized = hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[/, '')
-    .replace(/\]$/, '')
-    .replace(/\.$/, '');
+  const normalized = normalizeHostname(hostname);
 
   if (!normalized) return true;
   if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true;
@@ -123,6 +152,78 @@ export function isBlockedProxyHostname(hostname: string): boolean {
   if (normalized.includes(':')) return isBlockedIPv6(normalized);
 
   return false;
+}
+
+async function resolveOptional(
+  resolver: (hostname: string) => Promise<string[]>,
+  hostname: string
+): Promise<string[]> {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+export async function resolveProxyTarget(
+  hostname: string,
+  resolver: ProxyResolver = defaultResolver
+): Promise<
+  | { ok: true; address: string; family: 4 | 6 }
+  | { ok: false; status: number; error: string; details?: string }
+> {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized) {
+    return { ok: false, status: 400, error: 'Proxy URL host is not allowed' };
+  }
+
+  const literalIpFamily = isIP(normalized);
+  if (literalIpFamily) {
+    if (isBlockedProxyHostname(normalized)) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Proxy URL host is not allowed',
+        details: 'Local, private, link-local, and metadata hosts are blocked',
+      };
+    }
+
+    return {
+      ok: true,
+      address: normalized,
+      family: literalIpFamily as 4 | 6,
+    };
+  }
+
+  const [ipv4Addresses, ipv6Addresses] = await Promise.all([
+    resolveOptional(resolver.resolve4, normalized),
+    resolveOptional(resolver.resolve6, normalized),
+  ]);
+
+  const resolvedAddresses = [
+    ...ipv4Addresses.map((address) => ({ address, family: 4 as const })),
+    ...ipv6Addresses.map((address) => ({ address, family: 6 as const })),
+  ];
+
+  if (resolvedAddresses.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Proxy URL host could not be resolved',
+    };
+  }
+
+  const blockedAddress = resolvedAddresses.find(({ address }) => isBlockedProxyHostname(address));
+  if (blockedAddress) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Proxy URL host is not allowed',
+      details: 'Resolved proxy targets cannot be local, private, link-local, or metadata addresses',
+    };
+  }
+
+  return { ok: true, ...resolvedAddresses[0] };
 }
 
 export function sanitizeProxyHeaders(headers: Record<string, unknown>): Record<string, string> {
@@ -204,15 +305,118 @@ export function validateProxyRequestBody(body: unknown): ProxyValidationResult {
   };
 }
 
+export async function validateProxyRequest(
+  body: unknown,
+  resolver: ProxyResolver = defaultResolver
+): Promise<ProxyValidationResult> {
+  const validation = validateProxyRequestBody(body);
+  if (!validation.ok) return validation;
+
+  const parsedUrl = new URL(validation.request.url);
+  const target = await resolveProxyTarget(parsedUrl.hostname, resolver);
+  if (!target.ok) return target;
+
+  return {
+    ok: true,
+    request: {
+      ...validation.request,
+      targetAddress: target.address,
+      targetFamily: target.family,
+    },
+  };
+}
+
+function stringifyProxyBody(body: unknown, method: string): string | undefined {
+  if (body === undefined || method === 'GET' || method === 'HEAD') return undefined;
+  return typeof body === 'string' ? body : JSON.stringify(body);
+}
+
+function performProxyRequest(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+  body: unknown,
+  timeout: number,
+  targetAddress?: string,
+  targetFamily?: 4 | 6
+): Promise<ProxyResponse> {
+  const parsedUrl = new URL(url);
+  const requestBody = stringifyProxyBody(body, method);
+  const transport = parsedUrl.protocol === 'https:' ? httpsRequest : httpRequest;
+  const requestHeaders = {
+    ...headers,
+    ...(requestBody !== undefined ? { 'Content-Length': Buffer.byteLength(requestBody).toString() } : {}),
+  };
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+      callback();
+    };
+
+    const options: RequestOptions = {
+      protocol: parsedUrl.protocol,
+      hostname: normalizeHostname(parsedUrl.hostname),
+      port: parsedUrl.port || undefined,
+      path: `${parsedUrl.pathname}${parsedUrl.search}`,
+      method,
+      headers: requestHeaders,
+      lookup: targetAddress && targetFamily
+        ? (_hostname, _options, callback) => callback(null, targetAddress, targetFamily)
+        : undefined,
+    };
+
+    const req = transport(options, (response) => {
+      const chunks: Buffer[] = [];
+
+      response.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+
+      response.on('end', () => {
+        finish(() => {
+          resolve({
+            ok: response.statusCode !== undefined && response.statusCode >= 200 && response.statusCode < 300,
+            status: response.statusCode ?? 0,
+            statusText: response.statusMessage ?? '',
+            headers: Object.fromEntries(
+              Object.entries(response.headers).map(([name, value]) => [
+                name,
+                Array.isArray(value) ? value.join(', ') : value ?? '',
+              ])
+            ),
+            text: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      });
+    });
+
+    timeoutId = setTimeout(() => {
+      req.destroy(Object.assign(new Error('Request timeout'), { name: 'AbortError' }));
+    }, timeout);
+
+    req.on('error', (error) => {
+      finish(() => reject(error));
+    });
+
+    if (requestBody !== undefined) req.write(requestBody);
+    req.end();
+  });
+}
+
 export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
   .post('/request', async ({ body, set }) => {
-    const validation = validateProxyRequestBody(body);
+    const validation = await validateProxyRequest(body);
     if (!validation.ok) {
       set.status = validation.status;
       return { error: validation.error, details: validation.details };
     }
 
-    const { url, method, headers, body: reqBody, timeout } = validation.request;
+    const { url, method, headers, body: reqBody, timeout, targetAddress, targetFamily } = validation.request;
     const proxyHeaders = {
       'User-Agent': 'Profitmaker-Server/3.0',
       Accept: 'application/json',
@@ -220,22 +424,18 @@ export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
       ...headers,
     };
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeout);
-
     try {
-      const response = await fetch(url, {
+      const response = await performProxyRequest(
+        url,
         method,
-        headers: proxyHeaders,
-        body: reqBody !== undefined && method !== 'GET' && method !== 'HEAD'
-          ? JSON.stringify(reqBody)
-          : undefined,
-        signal: controller.signal,
-      });
+        proxyHeaders,
+        reqBody,
+        timeout,
+        targetAddress,
+        targetFamily
+      );
 
-      clearTimeout(timeoutId);
-
-      const responseData = await response.text();
+      const responseData = response.text;
       let parsedData;
       try {
         parsedData = JSON.parse(responseData);
@@ -248,11 +448,10 @@ export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
         success: response.ok,
         status: response.status,
         statusText: response.statusText,
-        headers: Object.fromEntries(response.headers.entries()),
+        headers: response.headers,
         data: parsedData,
       };
     } catch (error) {
-      clearTimeout(timeoutId);
       if (error instanceof Error && error.name === 'AbortError') {
         set.status = 408;
         return { error: 'Request timeout', details: `Timed out after ${timeout}ms` };

--- a/packages/server/src/routes/proxy.ts
+++ b/packages/server/src/routes/proxy.ts
@@ -1,14 +1,218 @@
 import { Elysia } from 'elysia';
 
-export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
-  .post('/request', async ({ body, set }) => {
-    const { url, method = 'GET', headers = {}, body: reqBody, timeout = 30000 } = body as any;
+const DEFAULT_PROXY_TIMEOUT_MS = 30_000;
+const MIN_PROXY_TIMEOUT_MS = 1_000;
+const MAX_PROXY_TIMEOUT_MS = 60_000;
 
-    if (!url) {
-      set.status = 400;
-      return { error: 'URL is required' };
+const allowedProxyMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD']);
+const blockedProxyHeaders = new Set([
+  'connection',
+  'content-length',
+  'expect',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+type ProxyValidationResult =
+  | {
+      ok: true;
+      request: {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        body: unknown;
+        timeout: number;
+      };
+    }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+      details?: string;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseIPv4Address(hostname: string): number[] | null {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return null;
+
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return NaN;
+    const value = Number(part);
+    return Number.isInteger(value) && value >= 0 && value <= 255 ? value : NaN;
+  });
+
+  return octets.every(Number.isFinite) ? octets : null;
+}
+
+function isBlockedIPv4(octets: number[]): boolean {
+  const [a, b] = octets;
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    a >= 224 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function parseIPv4MappedIPv6(hostname: string): number[] | null {
+  if (!hostname.startsWith('::ffff:')) return null;
+
+  const tail = hostname.slice('::ffff:'.length);
+  const dottedIPv4 = parseIPv4Address(tail);
+  if (dottedIPv4) return dottedIPv4;
+
+  const parts = tail.split(':');
+  if (parts.length !== 2) return null;
+
+  if (parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) {
+    return null;
+  }
+
+  const words = parts.map((part) => Number.parseInt(part, 16));
+  if (words.some((word) => !Number.isInteger(word) || word < 0 || word > 0xffff)) {
+    return null;
+  }
+
+  const [high, low] = words;
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
+}
+
+function isBlockedIPv6(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  const mappedIPv4 = parseIPv4MappedIPv6(normalized);
+  if (mappedIPv4) return isBlockedIPv4(mappedIPv4);
+
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fe80:') ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd')
+  );
+}
+
+export function isBlockedProxyHostname(hostname: string): boolean {
+  const normalized = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .replace(/\.$/, '');
+
+  if (!normalized) return true;
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true;
+  if (normalized === 'metadata.google.internal') return true;
+
+  const ipv4 = parseIPv4Address(normalized);
+  if (ipv4) return isBlockedIPv4(ipv4);
+  if (normalized.includes(':')) return isBlockedIPv6(normalized);
+
+  return false;
+}
+
+export function sanitizeProxyHeaders(headers: Record<string, unknown>): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    const headerName = name.trim();
+    const lowerName = headerName.toLowerCase();
+
+    if (!headerName || blockedProxyHeaders.has(lowerName) || lowerName.startsWith('sec-')) {
+      continue;
     }
 
+    if (typeof value === 'string') {
+      sanitized[headerName] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      sanitized[headerName] = String(value);
+    } else if (Array.isArray(value)) {
+      sanitized[headerName] = value.map(String).join(', ');
+    }
+  }
+
+  return sanitized;
+}
+
+export function validateProxyRequestBody(body: unknown): ProxyValidationResult {
+  if (!isRecord(body)) {
+    return { ok: false, status: 400, error: 'Proxy request body must be an object' };
+  }
+
+  const rawUrl = body.url;
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return { ok: false, status: 400, error: 'URL is required' };
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return { ok: false, status: 400, error: 'Invalid URL' };
+  }
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return { ok: false, status: 400, error: 'Only http and https proxy URLs are allowed' };
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    return { ok: false, status: 400, error: 'Credentials in proxy URLs are not allowed' };
+  }
+
+  if (isBlockedProxyHostname(parsedUrl.hostname)) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Proxy URL host is not allowed',
+      details: 'Local, private, link-local, and metadata hosts are blocked',
+    };
+  }
+
+  const method = typeof body.method === 'string' ? body.method.toUpperCase() : 'GET';
+  if (!allowedProxyMethods.has(method)) {
+    return { ok: false, status: 400, error: `Proxy method ${method} is not allowed` };
+  }
+
+  const timeout =
+    typeof body.timeout === 'number' && Number.isFinite(body.timeout)
+      ? Math.min(Math.max(body.timeout, MIN_PROXY_TIMEOUT_MS), MAX_PROXY_TIMEOUT_MS)
+      : DEFAULT_PROXY_TIMEOUT_MS;
+
+  return {
+    ok: true,
+    request: {
+      url: parsedUrl.toString(),
+      method,
+      headers: sanitizeProxyHeaders(isRecord(body.headers) ? body.headers : {}),
+      body: body.body,
+      timeout,
+    },
+  };
+}
+
+export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
+  .post('/request', async ({ body, set }) => {
+    const validation = validateProxyRequestBody(body);
+    if (!validation.ok) {
+      set.status = validation.status;
+      return { error: validation.error, details: validation.details };
+    }
+
+    const { url, method, headers, body: reqBody, timeout } = validation.request;
     const proxyHeaders = {
       'User-Agent': 'Profitmaker-Server/3.0',
       Accept: 'application/json',
@@ -23,7 +227,9 @@ export const proxyRoutes = new Elysia({ prefix: '/api/proxy' })
       const response = await fetch(url, {
         method,
         headers: proxyHeaders,
-        body: reqBody ? JSON.stringify(reqBody) : undefined,
+        body: reqBody !== undefined && method !== 'GET' && method !== 'HEAD'
+          ? JSON.stringify(reqBody)
+          : undefined,
         signal: controller.signal,
       });
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -9,5 +9,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
 }

--- a/packages/types/src/dataProviders.ts
+++ b/packages/types/src/dataProviders.ts
@@ -123,6 +123,7 @@ export interface CCXTBrowserConfig {
 // Configuration for CCXT Server - УПРОЩЕННАЯ ВЕРСИЯ
 export interface CCXTServerConfig {
   serverUrl: string;
+  socketUrl?: string; // Optional Socket.IO URL; defaults to serverUrl port + 1 when a port is present
   token?: string; // Authentication token for server
   timeout?: number;
   sandbox?: boolean;
@@ -335,4 +336,4 @@ export interface ChartUpdateEvent {
   timestamp: number;
 }
 
-export type ChartUpdateListener = (event: ChartUpdateEvent) => void; 
+export type ChartUpdateListener = (event: ChartUpdateEvent) => void;

--- a/src/components/TestServerProvider.tsx
+++ b/src/components/TestServerProvider.tsx
@@ -186,7 +186,7 @@ Low: $${parseFloat(ticker.l[1]).toLocaleString()}
         name: 'Test Server',
         type: 'ccxt-server',
         exchanges: ['kraken'],
-        status: 'active',
+        status: 'connected',
         priority: 1,
         config: {
           serverUrl,

--- a/src/components/widgets/MarketDataWidget.tsx
+++ b/src/components/widgets/MarketDataWidget.tsx
@@ -7,11 +7,11 @@ import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { useCandles, useTrades, useOrderBook, useDataProviders } from '../../hooks/useDataProvider';
 import { formatTimestamp, formatPrice, formatVolume } from '../../utils/formatters';
-import { 
-  TrendingUp, 
-  TrendingDown, 
-  Activity, 
-  Clock, 
+import {
+  TrendingUp,
+  TrendingDown,
+  Activity,
+  Clock,
   Wifi,
   WifiOff,
   BarChart3,
@@ -46,32 +46,35 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
 
   // Data subscriptions
   const candles = useCandles(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-candles`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-candles`,
+    showCandles
   );
 
   const trades = useTrades(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-trades`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-trades`,
+    showTrades
   );
 
   const orderbook = useOrderBook(
-    symbol, 
-    exchange, 
-    selectedProvider, 
-    dashboardId, 
-    `${widgetId}-orderbook`
+    symbol,
+    exchange,
+    selectedProvider,
+    dashboardId,
+    `${widgetId}-orderbook`,
+    showOrderBook
   );
 
   // Get last candle for price display
-  const lastCandle = candles.data && candles.data.length > 0 
-    ? candles.data[candles.data.length - 1] 
+  const lastCandle = candles.data && candles.data.length > 0
+    ? candles.data[candles.data.length - 1]
     : null;
 
   const priceChange = lastCandle && candles.data && candles.data.length > 1
@@ -94,7 +97,7 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
     const anyConnected = (showCandles && candles.isSubscribed) ||
                         (showTrades && trades.isSubscribed) ||
                         (showOrderBook && orderbook.isSubscribed);
-    
+
     const anyLoading = (showCandles && candles.loading) ||
                       (showTrades && trades.loading) ||
                       (showOrderBook && orderbook.loading);
@@ -188,7 +191,7 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
                     </span>
                   </div>
                 </div>
-                
+
                 <div className="grid grid-cols-4 gap-4 text-sm">
                   <div>
                     <p className="text-muted-foreground">Open</p>
@@ -309,8 +312,8 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
                 {recentTrades.map((trade, index) => (
                   <div key={trade.id || index} className="flex justify-between items-center py-1 text-sm">
                     <div className="flex items-center gap-2">
-                      <Badge 
-                        variant={trade.side === 'buy' ? 'default' : 'destructive'} 
+                      <Badge
+                        variant={trade.side === 'buy' ? 'default' : 'destructive'}
                         className="text-xs px-1 py-0"
                       >
                         {trade.side}
@@ -341,4 +344,4 @@ export const MarketDataWidget: React.FC<MarketDataWidgetProps> = ({
       )}
     </div>
   );
-}; 
+};

--- a/src/components/widgets/UserTradesTab.tsx
+++ b/src/components/widgets/UserTradesTab.tsx
@@ -32,64 +32,77 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   accounts,
   settings
 }) => {
-  const [trades, setTrades] = useState<Array<Trade & { 
+  const [trades, setTrades] = useState<Array<Trade & {
     accountId: string;
     exchange: string;
     email: string;
   }>>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Data provider integration - get methods only
   const dataProvider = useDataProviderStore();
 
   // Load trades for accounts
   const loadTrades = useCallback(async () => {
     if (!accounts.length) return;
-    
+
     setLoading(true);
     setError(null);
-    
+
     try {
       console.log(`📊 Loading trades for ${accounts.length} account(s)`);
-      
+
       const allTrades: (Trade & { accountId: string; exchange: string; email: string; })[] = [];
-      
+
       // Load trades from each account
       for (const account of accounts) {
         try {
           console.log(`🔄 Fetching trades for account ${account.id} (${account.exchange})`);
-          
+
           const trades = await dataProvider.fetchMyTrades(
             account.id,
             undefined, // symbol - get all symbols
             undefined, // since - get recent trades
             settings.tradesLimit
           );
-          
+
           // Transform and add account info
-          const tradesWithAccount = trades.map(trade => ({
-            ...trade,
-            accountId: account.id,
-            exchange: account.exchange || 'Unknown',
-            email: account.email || 'Unknown'
-          }));
-          
+          const tradesWithAccount = trades.map(trade => {
+            const rawTrade = trade as Partial<Trade> & typeof trade;
+
+            return {
+              id: trade.id,
+              timestamp: trade.timestamp,
+              symbol: rawTrade.symbol || 'Unknown',
+              side: trade.side,
+              amount: trade.amount,
+              price: trade.price,
+              cost: typeof rawTrade.cost === 'number' ? rawTrade.cost : trade.price * trade.amount,
+              fee: rawTrade.fee,
+              order: rawTrade.order,
+              info: rawTrade.info,
+              accountId: account.id,
+              exchange: account.exchange || 'Unknown',
+              email: account.email || 'Unknown'
+            };
+          });
+
           allTrades.push(...tradesWithAccount);
-          
+
           console.log(`✅ Loaded ${trades.length} trades for account ${account.id}`);
         } catch (error) {
           console.error(`❌ Failed to load trades for account ${account.id}:`, error);
           // Continue with other accounts even if one fails
         }
       }
-      
+
       // Sort trades by timestamp (newest first)
       allTrades.sort((a, b) => b.timestamp - a.timestamp);
-      
+
       setTrades(allTrades);
       console.log(`✅ Total trades loaded: ${allTrades.length}`);
-      
+
     } catch (error) {
       console.error('❌ Failed to load trades:', error);
       setError(error instanceof Error ? error.message : 'Failed to load trades');
@@ -109,13 +122,13 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   // Format currency value
   const formatCurrency = useCallback((value: number, currency?: string) => {
     if (value === 0) return '0';
-    
+
     if (value < 0.001) {
       return value.toFixed(8);
     } else if (value < 1) {
       return value.toFixed(6);
     } else if (value < 1000) {
-      return value.toFixed(4);  
+      return value.toFixed(4);
     } else {
       return value.toFixed(2);
     }
@@ -135,10 +148,10 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
     overscan: 5,
   });
 
-  const renderTradeRow = useCallback((trade: Trade & { 
-    accountId: string; 
-    exchange: string; 
-    email: string; 
+  const renderTradeRow = useCallback((trade: Trade & {
+    accountId: string;
+    exchange: string;
+    email: string;
   }, index: number, style?: React.CSSProperties) => (
     <div
       key={trade.id}
@@ -162,33 +175,33 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
       <div className="text-center min-w-0 flex-1">
         <div className="font-medium text-terminal-text">{trade.symbol}</div>
         <div className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${
-          trade.side === 'buy' 
-            ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200' 
+          trade.side === 'buy'
+            ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200'
             : 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200'
         }`}>
           {trade.side === 'buy' ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
           {trade.side.toUpperCase()}
         </div>
       </div>
-      
+
       {/* Amount */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">{formatCurrency(trade.amount)}</div>
         <div className="text-xs text-terminal-muted">Amount</div>
       </div>
-      
+
       {/* Price */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">{formatCurrency(trade.price)}</div>
         <div className="text-xs text-terminal-muted">Price</div>
       </div>
-      
+
       {/* Cost */}
       <div className="text-right min-w-0 flex-1">
         <div className="font-medium text-terminal-text">{formatCurrency(trade.cost)}</div>
         <div className="text-xs text-terminal-muted">Total</div>
       </div>
-      
+
       {/* Fee */}
       <div className="text-right min-w-0 flex-1">
         <div className="text-terminal-text">
@@ -218,7 +231,7 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
         <div className="text-center">
           <TrendingDown className="w-8 h-8 text-red-500 mb-2 mx-auto" />
           <p className="text-red-500">Error: {error}</p>
-          <button 
+          <button
             onClick={loadTrades}
             className="mt-2 px-3 py-1 bg-terminal-accent/20 hover:bg-terminal-accent/30 rounded text-xs"
           >
@@ -280,7 +293,7 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
         ) : (
           // Render normally for smaller lists
           <div className="overflow-auto">
-            {trades.map((trade, index) => 
+            {trades.map((trade, index) =>
               renderTradeRow(trade, index)
             )}
           </div>
@@ -290,4 +303,4 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
   );
 };
 
-export default UserTradesTab; 
+export default UserTradesTab;

--- a/src/components/widgets/UserTradesTab.tsx
+++ b/src/components/widgets/UserTradesTab.tsx
@@ -45,7 +45,12 @@ const UserTradesTab: React.FC<UserTradesTabProps> = ({
 
   // Load trades for accounts
   const loadTrades = useCallback(async () => {
-    if (!accounts.length) return;
+    if (!accounts.length) {
+      setTrades([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);

--- a/src/context/WidgetContext.tsx
+++ b/src/context/WidgetContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { toast } from "sonner";
 
-export type WidgetType = 'chart' | 'portfolio' | 'orderForm' | 'transactions' | 'watchlist' | 'news' | 'calendar' | 'positions' | 'orderbook' | 'orderbookV2' | 'trades' | 'tradesV2' | 'dataProviderSettings' | 'dataProviderDemo' | 'dataProviderSetup' | 'dataProviderDebug' | 'userBalances';
+export type WidgetType = 'chart' | 'portfolio' | 'orderForm' | 'transactions' | 'watchlist' | 'news' | 'calendar' | 'positions' | 'orderbook' | 'orderbookV2' | 'trades' | 'tradesV2' | 'dataProviderSettings' | 'dataProviderDemo' | 'dataProviderSetup' | 'dataProviderDebug' | 'userBalances' | 'userTradingData';
 
 export interface WidgetGroup {
   id: string;
@@ -59,7 +59,8 @@ const defaultWidgetSizes: Record<WidgetType, { width: number; height: number }> 
   dataProviderDemo: { width: 700, height: 400 },
   dataProviderSetup: { width: 500, height: 400 },
   dataProviderDebug: { width: 700, height: 500 },
-  userBalances: { width: 700, height: 600 }
+  userBalances: { width: 700, height: 600 },
+  userTradingData: { width: 700, height: 600 }
 };
 
 const widgetTitles: Record<WidgetType, string> = {
@@ -444,4 +445,3 @@ export const useWidget = () => {
   }
   return context;
 };
-

--- a/src/hooks/useDataProvider.ts
+++ b/src/hooks/useDataProvider.ts
@@ -1,18 +1,19 @@
 import { useEffect, useCallback, useMemo } from 'react';
 import { useDataProviderStore } from '../store/dataProviderStore';
-import { 
-  DataType, 
-  Candle, 
-  Trade, 
-  OrderBook, 
-  CreateSubscriptionParams,
-  DataState
+import {
+  DataType,
+  Timeframe,
+  MarketType,
+  ProviderOperationResult
 } from '../types/dataProviders';
+
+const DEFAULT_TIMEFRAME: Timeframe = '1m';
+const DEFAULT_MARKET: MarketType = 'spot';
 
 // NEW: Hook for provider-exchange mappings
 export const useProviderMappings = (exchanges: string[]) => {
   const { getProviderExchangeMappings } = useDataProviderStore();
-  
+
   return useMemo(() => {
     return getProviderExchangeMappings(exchanges);
   }, [exchanges, getProviderExchangeMappings]);
@@ -21,7 +22,7 @@ export const useProviderMappings = (exchanges: string[]) => {
 // NEW: Hook for getting provider for specific exchange
 export const useProviderForExchange = (exchange: string) => {
   const { getProviderForExchange } = useDataProviderStore();
-  
+
   return useMemo(() => {
     return getProviderForExchange(exchange);
   }, [exchange, getProviderForExchange]);
@@ -33,67 +34,68 @@ export const useCandles = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getCandles,
+    getSubscriptionKey,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const candleData = data.candles[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const candleData = getCandles(exchange, symbol, DEFAULT_TIMEFRAME, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-candles-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-candles-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    try {
-      const params: CreateSubscriptionParams = {
-        symbol,
-        dataType: 'candles',
-        exchange,
-        dashboardId,
-        widgetId,
-        providerId: actualProviderId
-      };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-      return await createSubscription(params);
+    try {
+      return await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'candles',
+        DEFAULT_TIMEFRAME,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
     } catch (error) {
       console.error('🛡️ Safe error handling for candles subscription:', error);
       return { success: false, error: `Subscription error: ${error}` };
     }
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   // Automatic subscription/unsubscription
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: candleData?.data || null,
-    loading: candleData?.loading || false,
-    error: candleData?.error || null,
-    lastUpdate: candleData?.lastUpdate || 0,
+    data: candleData.length > 0 ? candleData : null,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!candleData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -103,61 +105,62 @@ export const useTrades = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getSubscriptionKey,
+    getTrades,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const tradeData = data.trades[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const tradeData = getTrades(exchange, symbol, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-trades-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-trades-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    const params: CreateSubscriptionParams = {
-      symbol,
-      dataType: 'trades',
-      exchange,
-      dashboardId,
-      widgetId,
-      providerId: actualProviderId
-    };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-    return await createSubscription(params);
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+    return await subscribeToData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'trades',
+      undefined,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: tradeData?.data || null,
-    loading: tradeData?.loading || false,
-    error: tradeData?.error || null,
-    lastUpdate: tradeData?.lastUpdate || 0,
+    data: tradeData.length > 0 ? tradeData : null,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!tradeData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -167,61 +170,62 @@ export const useOrderBook = (
   exchange: string,
   providerId?: string,
   dashboardId: string = 'default',
-  widgetId: string = 'default'
+  widgetId: string = 'default',
+  enabled: boolean = true
 ) => {
   const {
-    data,
-    createSubscription,
-    removeSubscription,
-    providers,
-    activeProviderId
+    activeProviderId,
+    activeSubscriptions,
+    getOrderBook,
+    getSubscriptionKey,
+    subscribe: subscribeToData,
+    unsubscribe: unsubscribeFromData
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const dataKey = `${exchange}-${symbol}`;
-  const orderBookData = data.orderbook[dataKey];
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  const subscription = activeSubscriptions[subscriptionKey];
+  const orderBookData = getOrderBook(exchange, symbol, DEFAULT_MARKET);
 
-  const subscriptionId = useMemo(() => 
-    actualProviderId ? `${actualProviderId}-${exchange}-${symbol}-orderbook-${dashboardId}-${widgetId}` : null,
+  const subscriptionId = useMemo(() =>
+    `${actualProviderId || 'auto'}-${exchange}-${symbol}-orderbook-${dashboardId}-${widgetId}`,
     [actualProviderId, exchange, symbol, dashboardId, widgetId]
   );
 
-  const subscribe = useCallback(async () => {
-    if (!actualProviderId || !subscriptionId) return;
-    
-    const params: CreateSubscriptionParams = {
-      symbol,
-      dataType: 'orderbook',
-      exchange,
-      dashboardId,
-      widgetId,
-      providerId: actualProviderId
-    };
+  const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
+    if (!enabled || !symbol || !exchange) return;
 
-    return await createSubscription(params);
-  }, [actualProviderId, symbol, exchange, dashboardId, widgetId, subscriptionId, createSubscription]);
+    return await subscribeToData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'orderbook',
+      undefined,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
-    if (subscriptionId) {
-      removeSubscription(subscriptionId);
-    }
-  }, [subscriptionId, removeSubscription]);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(subscriptionId, exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (actualProviderId && subscriptionId) {
+    if (enabled && subscriptionId) {
       subscribe();
       return () => unsubscribe();
     }
-  }, [actualProviderId, subscriptionId]);
+  }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
-    data: orderBookData?.data || null,
-    loading: orderBookData?.loading || false,
-    error: orderBookData?.error || null,
-    lastUpdate: orderBookData?.lastUpdate || 0,
+    data: orderBookData,
+    loading: enabled && !!subscription && subscription.lastUpdate === 0,
+    error: null,
+    lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
-    isSubscribed: !!subscriptionId && !!orderBookData
+    isSubscribed: enabled && !!subscription
   };
 };
 
@@ -235,27 +239,30 @@ export const useMarketData = (
   widgetId: string = 'default'
 ) => {
   const candles = useCandles(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('candles') ? `${widgetId}-candles` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-candles`,
+    dataTypes.includes('candles')
   );
-  
+
   const trades = useTrades(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('trades') ? `${widgetId}-trades` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-trades`,
+    dataTypes.includes('trades')
   );
-  
+
   const orderbook = useOrderBook(
-    symbol, 
-    exchange, 
-    providerId, 
-    dashboardId, 
-    dataTypes.includes('orderbook') ? `${widgetId}-orderbook` : ''
+    symbol,
+    exchange,
+    providerId,
+    dashboardId,
+    `${widgetId}-orderbook`,
+    dataTypes.includes('orderbook')
   );
 
   const loading = (dataTypes.includes('candles') && candles.loading) ||
@@ -288,7 +295,6 @@ export const useDataProviders = () => {
     setActiveProvider,
     addProvider,
     removeProvider,
-    initializeProvider,
     loading
   } = useDataProviderStore();
 
@@ -302,7 +308,6 @@ export const useDataProviders = () => {
     setActiveProvider,
     addProvider,
     removeProvider,
-    initializeProvider,
     loading
   };
 };
@@ -310,43 +315,42 @@ export const useDataProviders = () => {
 // Hook for getting connection information
 export const useConnectionStats = () => {
   const {
-    connectionStats,
-    connections,
-    subscriptions,
-    getActiveSubscriptions,
-    closeConnection
+    activeSubscriptions,
+    forceCloseSubscription
   } = useDataProviderStore();
 
   const stats = useMemo(() => {
-    const connectionList = Object.values(connectionStats);
-    const subscriptionList = getActiveSubscriptions();
-    
+    const subscriptionList = Object.entries(activeSubscriptions).map(([id, subscription]) => ({
+      id,
+      ...subscription
+    }));
+
     return {
-      total: connectionList.length,
-      connected: connectionList.filter(c => c.status === 'connected').length,
-      connecting: connectionList.filter(c => c.status === 'connecting').length,
-      error: connectionList.filter(c => c.status === 'error').length,
-      disconnected: connectionList.filter(c => c.status === 'disconnected').length,
+      total: subscriptionList.length,
+      connected: subscriptionList.filter(s => s.isActive && !s.isFallback).length,
+      connecting: subscriptionList.filter(s => s.isActive && s.lastUpdate === 0).length,
+      error: 0,
+      disconnected: subscriptionList.filter(s => !s.isActive).length,
       totalSubscriptions: subscriptionList.length,
-      connections: connectionList,
+      connections: subscriptionList,
       subscriptions: subscriptionList
     };
-  }, [connectionStats, getActiveSubscriptions]);
+  }, [activeSubscriptions]);
 
   return {
     ...stats,
-    closeConnection
+    closeConnection: forceCloseSubscription
   };
 };
 
 // Hook for checking exchange availability
 export const useExchangeSupport = (exchangeId: string) => {
   const { providers } = useDataProviderStore();
-  
+
   return useMemo(() => {
     const supportingProviders = Object.values(providers).filter(provider => {
       if (provider.type === 'ccxt-browser' || provider.type === 'ccxt-server') {
-        return provider.config.exchangeId === exchangeId;
+        return provider.exchanges.includes('*') || provider.exchanges.includes(exchangeId);
       }
       return false;
     });
@@ -357,4 +361,4 @@ export const useExchangeSupport = (exchangeId: string) => {
       count: supportingProviders.length
     };
   }, [providers, exchangeId]);
-}; 
+};

--- a/src/hooks/useDataProvider.ts
+++ b/src/hooks/useDataProvider.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo, useState } from 'react';
 import { useDataProviderStore } from '../store/dataProviderStore';
 import {
   DataType,
@@ -47,7 +47,8 @@ export const useCandles = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const candleData = getCandles(exchange, symbol, DEFAULT_TIMEFRAME, DEFAULT_MARKET);
 
@@ -57,10 +58,13 @@ export const useCandles = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
     try {
-      return await subscribeToData(
+      const result = await subscribeToData(
         subscriptionId,
         exchange,
         symbol,
@@ -69,29 +73,46 @@ export const useCandles = (
         DEFAULT_MARKET,
         actualProviderId ? { providerId: actualProviderId } : undefined
       );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
     } catch (error) {
       console.error('🛡️ Safe error handling for candles subscription:', error);
-      return { success: false, error: `Subscription error: ${error}` };
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
     }
   }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
 
   const unsubscribe = useCallback(() => {
+    setLastError(null);
     if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'candles', DEFAULT_TIMEFRAME, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+    unsubscribeFromData(
+      subscriptionId,
+      exchange,
+      symbol,
+      'candles',
+      DEFAULT_TIMEFRAME,
+      DEFAULT_MARKET,
+      actualProviderId ? { providerId: actualProviderId } : undefined
+    );
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   // Automatic subscription/unsubscription
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: candleData.length > 0 ? candleData : null,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -118,7 +139,8 @@ export const useTrades = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'trades', undefined, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const tradeData = getTrades(exchange, symbol, DEFAULT_MARKET);
 
@@ -128,9 +150,34 @@ export const useTrades = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
-    return await subscribeToData(
+    try {
+      const result = await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'trades',
+        undefined,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
+    } catch (error) {
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
+    }
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
+
+  const unsubscribe = useCallback(() => {
+    setLastError(null);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(
       subscriptionId,
       exchange,
       symbol,
@@ -139,24 +186,23 @@ export const useTrades = (
       DEFAULT_MARKET,
       actualProviderId ? { providerId: actualProviderId } : undefined
     );
-  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
-
-  const unsubscribe = useCallback(() => {
-    if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'trades', undefined, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: tradeData.length > 0 ? tradeData : null,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -183,7 +229,8 @@ export const useOrderBook = (
   } = useDataProviderStore();
 
   const actualProviderId = providerId || activeProviderId;
-  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
+  const [lastError, setLastError] = useState<string | null>(null);
+  const subscriptionKey = getSubscriptionKey(exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET, actualProviderId || undefined);
   const subscription = activeSubscriptions[subscriptionKey];
   const orderBookData = getOrderBook(exchange, symbol, DEFAULT_MARKET);
 
@@ -193,9 +240,34 @@ export const useOrderBook = (
   );
 
   const subscribe = useCallback(async (): Promise<ProviderOperationResult | undefined> => {
-    if (!enabled || !symbol || !exchange) return;
+    if (!enabled || !symbol || !exchange) {
+      setLastError(null);
+      return;
+    }
 
-    return await subscribeToData(
+    try {
+      const result = await subscribeToData(
+        subscriptionId,
+        exchange,
+        symbol,
+        'orderbook',
+        undefined,
+        DEFAULT_MARKET,
+        actualProviderId ? { providerId: actualProviderId } : undefined
+      );
+      setLastError(result.success ? null : result.error || 'Subscription failed');
+      return result;
+    } catch (error) {
+      const message = `Subscription error: ${error instanceof Error ? error.message : String(error)}`;
+      setLastError(message);
+      return { success: false, error: message };
+    }
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
+
+  const unsubscribe = useCallback(() => {
+    setLastError(null);
+    if (!enabled || !symbol || !exchange) return;
+    unsubscribeFromData(
       subscriptionId,
       exchange,
       symbol,
@@ -204,24 +276,23 @@ export const useOrderBook = (
       DEFAULT_MARKET,
       actualProviderId ? { providerId: actualProviderId } : undefined
     );
-  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, subscribeToData]);
-
-  const unsubscribe = useCallback(() => {
-    if (!enabled || !symbol || !exchange) return;
-    unsubscribeFromData(subscriptionId, exchange, symbol, 'orderbook', undefined, DEFAULT_MARKET);
-  }, [enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
+  }, [actualProviderId, enabled, exchange, symbol, subscriptionId, unsubscribeFromData]);
 
   useEffect(() => {
-    if (enabled && subscriptionId) {
-      subscribe();
-      return () => unsubscribe();
+    if (!enabled || !subscriptionId) {
+      setLastError(null);
+      return;
     }
+    void subscribe().catch((error) => {
+      setLastError(`Subscription error: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    return () => unsubscribe();
   }, [enabled, subscribe, subscriptionId, unsubscribe]);
 
   return {
     data: orderBookData,
     loading: enabled && !!subscription && subscription.lastUpdate === 0,
-    error: null,
+    error: lastError,
     lastUpdate: subscription?.lastUpdate || 0,
     subscribe,
     unsubscribe,
@@ -327,7 +398,7 @@ export const useConnectionStats = () => {
 
     return {
       total: subscriptionList.length,
-      connected: subscriptionList.filter(s => s.isActive && !s.isFallback).length,
+      connected: subscriptionList.filter(s => s.isActive && !s.isFallback && s.lastUpdate !== 0).length,
       connecting: subscriptionList.filter(s => s.isActive && s.lastUpdate === 0).length,
       error: 0,
       disconnected: subscriptionList.filter(s => !s.isActive).length,

--- a/src/store/actions/ccxtActions.ts
+++ b/src/store/actions/ccxtActions.ts
@@ -16,7 +16,7 @@ export const createCCXTActions: StateCreator<
   // Intelligent CCXT method selection
   selectOptimalOrderBookMethod: (exchange: string, exchangeInstance: any): OrderBookMethodSelection => {
     console.log(`🔍 Analyzing ${exchange} capabilities to select optimal orderbook method...`);
-    
+
     // Check available exchange capabilities
     const capabilities: CCXTMethodCapabilities = {
       watchOrderBookForSymbols: !!exchangeInstance.has?.['watchOrderBookForSymbols'],
@@ -68,10 +68,12 @@ export const createCCXTActions: StateCreator<
       state.marketData = {
         candles: {},
         trades: {},
-        orderbook: {}
+        orderbook: {},
+        balance: {},
+        ticker: {}
       };
     });
 
     console.log(`🧹 Data provider store cleaned up`);
   }
-}); 
+});

--- a/src/store/actions/data/getterActions.ts
+++ b/src/store/actions/data/getterActions.ts
@@ -9,7 +9,7 @@ export interface DataGetterActions {
   getBalance: (accountId: string, walletType?: WalletType) => ExchangeBalances | null;
   getTicker: (exchange: string, symbol: string, market?: MarketType, maxAge?: number) => Ticker | null;
   getTickerWithRefresh: (exchange: string, symbol: string, market?: MarketType, forceRefresh?: boolean) => Promise<Ticker | null>;
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, providerId?: string) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
 }
 
@@ -65,9 +65,10 @@ export const createDataGetterActions: StateCreator<
     }
   },
 
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot'): string => {
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', providerId?: string): string => {
     let key = `${exchange}:${market}:${symbol}:${dataType}`;
     if (dataType === 'candles' && timeframe) key += `:${timeframe}`;
+    if (providerId) key += `:provider:${providerId}`;
     return key;
   },
 

--- a/src/store/actions/data/updaterActions.ts
+++ b/src/store/actions/data/updaterActions.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { DataProviderStore } from '../../types';
-import type { Candle, Trade, OrderBook, Ticker, ExchangeBalances, Timeframe, MarketType, WalletType } from '../../../types/dataProviders';
+import type { Candle, Trade, OrderBook, Ticker, ExchangeBalances, Timeframe, MarketType, WalletType, DataType, ActiveSubscription } from '../../../types/dataProviders';
 
 export interface DataUpdaterActions {
   updateCandles: (exchange: string, symbol: string, candles: Candle[], timeframe?: Timeframe, market?: MarketType) => void;
@@ -8,6 +8,28 @@ export interface DataUpdaterActions {
   updateOrderBook: (exchange: string, symbol: string, orderbook: OrderBook, market?: MarketType) => void;
   updateBalance: (accountId: string, balance: ExchangeBalances, walletType?: WalletType) => void;
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
+}
+
+function updateMatchingSubscriptionTimestamps(
+  activeSubscriptions: Record<string, ActiveSubscription>,
+  exchange: string,
+  symbol: string,
+  dataType: DataType,
+  timeframe: Timeframe | undefined,
+  market: MarketType
+) {
+  const now = Date.now();
+  Object.values(activeSubscriptions).forEach((subscription) => {
+    if (
+      subscription.key.exchange === exchange &&
+      subscription.key.symbol === symbol &&
+      subscription.key.dataType === dataType &&
+      subscription.key.timeframe === timeframe &&
+      subscription.key.market === market
+    ) {
+      subscription.lastUpdate = now;
+    }
+  });
 }
 
 export const createDataUpdaterActions: StateCreator<
@@ -52,10 +74,7 @@ export const createDataUpdaterActions: StateCreator<
         }
       }
 
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'candles', timeframe, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'candles', timeframe, market);
     });
 
     get().emitChartUpdateEvent({
@@ -78,10 +97,7 @@ export const createDataUpdaterActions: StateCreator<
       const combined = [...existing, ...trades];
       state.marketData.trades[exchange][market][symbol] = combined.slice(-1000);
 
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'trades', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'trades', undefined, market);
     });
   },
 
@@ -91,10 +107,7 @@ export const createDataUpdaterActions: StateCreator<
       if (!state.marketData.orderbook[exchange][market]) state.marketData.orderbook[exchange][market] = {};
       state.marketData.orderbook[exchange][market][symbol] = orderbook;
 
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'orderbook', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'orderbook', undefined, market);
     });
   },
 
@@ -104,10 +117,7 @@ export const createDataUpdaterActions: StateCreator<
       if (!state.marketData.balance[accountId]) state.marketData.balance[accountId] = {};
       state.marketData.balance[accountId][effectiveWalletType] = balance;
 
-      const subscriptionKey = get().getSubscriptionKey('', accountId, 'balance', undefined, effectiveWalletType as MarketType);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, '', accountId, 'balance', undefined, effectiveWalletType as MarketType);
     });
   },
 
@@ -117,10 +127,7 @@ export const createDataUpdaterActions: StateCreator<
       if (!state.marketData.ticker[exchange][market]) state.marketData.ticker[exchange][market] = {};
       state.marketData.ticker[exchange][market][symbol] = { ...ticker, lastUpdate: Date.now() };
 
-      const subscriptionKey = get().getSubscriptionKey(exchange, symbol, 'ticker', undefined, market);
-      if (state.activeSubscriptions[subscriptionKey]) {
-        state.activeSubscriptions[subscriptionKey].lastUpdate = Date.now();
-      }
+      updateMatchingSubscriptionTimestamps(state.activeSubscriptions, exchange, symbol, 'ticker', undefined, market);
     });
   },
 });

--- a/src/store/actions/fetching/restFetchingActions.ts
+++ b/src/store/actions/fetching/restFetchingActions.ts
@@ -40,7 +40,7 @@ export const createRestFetchingActions: StateCreator<
       exchangeInstance = createExchangeInstance(exchange, provider, ccxt);
     }
 
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, provider.id);
     const interval = get().dataFetchSettings.restIntervals[dataType];
 
     const fetchData = async () => {

--- a/src/store/actions/fetching/wsFetchingActions.ts
+++ b/src/store/actions/fetching/wsFetchingActions.ts
@@ -35,7 +35,7 @@ export const createWsFetchingActions: StateCreator<
       exchangeInstance = createExchangeInstance(exchange, provider, ccxtPro);
     }
 
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, provider.id);
 
     // Check WebSocket support
     let watchMethod: string;

--- a/src/store/actions/subscriptionActions.ts
+++ b/src/store/actions/subscriptionActions.ts
@@ -4,8 +4,27 @@ import type { DataType, ProviderOperationResult, Timeframe, MarketType, Subscrip
 
 export interface SubscriptionActions {
   subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: Pick<SubscriptionConfig, 'providerId'>) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
+}
+
+function findSubscriptionKey(
+  activeSubscriptions: DataProviderStore['activeSubscriptions'],
+  exchange: string,
+  symbol: string,
+  dataType: DataType,
+  timeframe: Timeframe | undefined,
+  market: MarketType,
+  providerId?: string
+): string | undefined {
+  return Object.entries(activeSubscriptions).find(([, subscription]) => (
+    subscription.key.exchange === exchange &&
+    subscription.key.symbol === symbol &&
+    subscription.key.dataType === dataType &&
+    subscription.key.timeframe === timeframe &&
+    subscription.key.market === market &&
+    (!providerId || subscription.providerId === providerId)
+  ))?.[0];
 }
 
 export const createSubscriptionActions: StateCreator<
@@ -16,9 +35,10 @@ export const createSubscriptionActions: StateCreator<
 > = (set, get) => ({
   // Deduplicated subscriptions management
   subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: SubscriptionConfig): Promise<ProviderOperationResult> => {
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
     const currentMethod = get().dataFetchSettings.method;
     const { providerId, ...subscriptionConfig } = config ?? {};
+    const effectiveProviderId = providerId ?? get().getProviderForExchange(exchange)?.id;
+    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, effectiveProviderId);
     const hasSubscriptionConfig = Object.keys(subscriptionConfig).length > 0;
 
     try {
@@ -47,7 +67,7 @@ export const createSubscriptionActions: StateCreator<
             isFallback: false, // Initially not fallback
             isActive: false,
             lastUpdate: 0,
-            providerId,
+            providerId: effectiveProviderId,
             config: hasSubscriptionConfig ? subscriptionConfig : undefined
           };
           needsStart = true;
@@ -74,8 +94,16 @@ export const createSubscriptionActions: StateCreator<
     }
   },
 
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot') => {
-    const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: Pick<SubscriptionConfig, 'providerId'>) => {
+    const effectiveProviderId = config?.providerId ?? get().getProviderForExchange(exchange)?.id;
+    const providerSubscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market, effectiveProviderId);
+    const legacySubscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
+    const activeSubscriptions = get().activeSubscriptions;
+    const subscriptionKey = activeSubscriptions[providerSubscriptionKey]
+      ? providerSubscriptionKey
+      : activeSubscriptions[legacySubscriptionKey]
+        ? legacySubscriptionKey
+        : findSubscriptionKey(activeSubscriptions, exchange, symbol, dataType, timeframe, market, effectiveProviderId) ?? providerSubscriptionKey;
 
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {

--- a/src/store/actions/subscriptionActions.ts
+++ b/src/store/actions/subscriptionActions.ts
@@ -1,9 +1,9 @@
 import type { StateCreator } from 'zustand';
 import type { DataProviderStore } from '../types';
-import type { DataType, ProviderOperationResult, Timeframe, MarketType } from '../../types/dataProviders';
+import type { DataType, ProviderOperationResult, Timeframe, MarketType, SubscriptionConfig } from '../../types/dataProviders';
 
 export interface SubscriptionActions {
-  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }) => Promise<ProviderOperationResult>;
+  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
 }
@@ -15,21 +15,23 @@ export const createSubscriptionActions: StateCreator<
   SubscriptionActions
 > = (set, get) => ({
   // Deduplicated subscriptions management
-  subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }): Promise<ProviderOperationResult> => {
+  subscribe: async (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot', config?: SubscriptionConfig): Promise<ProviderOperationResult> => {
     const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
     const currentMethod = get().dataFetchSettings.method;
-    
+    const { providerId, ...subscriptionConfig } = config ?? {};
+    const hasSubscriptionConfig = Object.keys(subscriptionConfig).length > 0;
+
     try {
       let needsStart = false;
       let needsRestart = false;
-      
+
       set(state => {
         // Look for existing subscription
         if (state.activeSubscriptions[subscriptionKey]) {
           // Increase subscriber count
           state.activeSubscriptions[subscriptionKey].subscriberCount++;
           console.log(`📈 Subscriber ${subscriberId} added to existing subscription: ${subscriptionKey} (count: ${state.activeSubscriptions[subscriptionKey].subscriberCount})`);
-          
+
           // IMPORTANT: Check if subscription method matches current settings
           if (state.activeSubscriptions[subscriptionKey].method !== currentMethod) {
             console.log(`🔄 Subscription ${subscriptionKey} method outdated (${state.activeSubscriptions[subscriptionKey].method} -> ${currentMethod})`);
@@ -45,7 +47,8 @@ export const createSubscriptionActions: StateCreator<
             isFallback: false, // Initially not fallback
             isActive: false,
             lastUpdate: 0,
-            config: config // Add config support
+            providerId,
+            config: hasSubscriptionConfig ? subscriptionConfig : undefined
           };
           needsStart = true;
                       console.log(`🆕 New subscription created: ${subscriptionKey} for subscriber ${subscriberId} (method: ${currentMethod}, config:`, config, ')');
@@ -73,12 +76,12 @@ export const createSubscriptionActions: StateCreator<
 
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market: MarketType = 'spot') => {
     const subscriptionKey = get().getSubscriptionKey(exchange, symbol, dataType, timeframe, market);
-    
+
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {
         state.activeSubscriptions[subscriptionKey].subscriberCount--;
         console.log(`📉 Subscriber ${subscriberId} removed from subscription: ${subscriptionKey} (count: ${state.activeSubscriptions[subscriptionKey].subscriberCount})`);
-        
+
         // If no subscribers left - stop data fetching
         if (state.activeSubscriptions[subscriptionKey].subscriberCount <= 0) {
           get().stopDataFetching(subscriptionKey);
@@ -91,10 +94,10 @@ export const createSubscriptionActions: StateCreator<
 
   forceCloseSubscription: (subscriptionKey: string) => {
     console.log(`🔨 Force closing subscription: ${subscriptionKey}`);
-    
+
     // Stop data fetching immediately
     get().stopDataFetching(subscriptionKey);
-    
+
     // Remove from active subscriptions
     set(state => {
       if (state.activeSubscriptions[subscriptionKey]) {
@@ -103,4 +106,4 @@ export const createSubscriptionActions: StateCreator<
       }
     });
   }
-}); 
+});

--- a/src/store/providers/ccxtServerProvider.ts
+++ b/src/store/providers/ccxtServerProvider.ts
@@ -145,6 +145,8 @@ export class CCXTServerProviderImpl {
         // Authenticate
         if (this.token) {
           this.socket!.emit('authenticate', { token: this.token });
+        } else {
+          resolve(this.socket!);
         }
       });
 

--- a/src/store/providers/ccxtServerProvider.ts
+++ b/src/store/providers/ccxtServerProvider.ts
@@ -13,6 +13,18 @@ interface ServerResponse<T = any> {
   details?: string;
 }
 
+export function deriveSocketUrl(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    if (url.port) {
+      url.port = String(Number(url.port) + 1);
+    }
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return serverUrl.replace(/\/$/, '');
+  }
+}
+
 /**
  * CCXT Server Provider Implementation
  * Взаимодействует с Express сервером для выполнения CCXT операций
@@ -21,6 +33,7 @@ interface ServerResponse<T = any> {
 export class CCXTServerProviderImpl {
   private provider: CCXTServerProvider;
   private baseUrl: string;
+  private socketUrl: string;
   private token?: string;
   private timeout: number;
   private socket?: Socket;
@@ -29,6 +42,7 @@ export class CCXTServerProviderImpl {
   constructor(provider: CCXTServerProvider) {
     this.provider = provider;
     this.baseUrl = provider.config.serverUrl.replace(/\/$/, ''); // Remove trailing slash
+    this.socketUrl = (provider.config.socketUrl || deriveSocketUrl(provider.config.serverUrl)).replace(/\/$/, '');
     this.token = provider.config.token;
     this.timeout = provider.config.timeout || 30000;
   }
@@ -112,9 +126,9 @@ export class CCXTServerProviderImpl {
       return this.socket;
     }
 
-    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.baseUrl}`);
+    console.log(`🔌 [CCXTServer] Connecting to WebSocket: ${this.socketUrl}`);
 
-    this.socket = io(this.baseUrl, {
+    this.socket = io(this.socketUrl, {
       transports: ['websocket'],
       timeout: this.timeout,
     });

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -17,7 +17,8 @@ import type {
   WalletType,
   ChartUpdateListener,
   ChartUpdateEvent,
-  ProviderExchangeMapping
+  ProviderExchangeMapping,
+  SubscriptionConfig
 } from '../types/dataProviders';
 import type { User } from './userStore';
 
@@ -26,16 +27,16 @@ export interface DataProviderState {
   // Data providers
   providers: Record<string, DataProvider>;
   activeProviderId: string | null; // Deprecated, kept for compatibility
-  
+
   // Data fetch settings
   dataFetchSettings: DataFetchSettings;
-  
+
   // Active subscriptions with deduplication
   activeSubscriptions: Record<string, ActiveSubscription>;
-  
+
   // REST cycles
   restCycles: Record<string, RestCycleManager>;
-  
+
   // Centralized data storage
   marketData: {
     candles: Record<string, Record<string, Record<string, Record<string, Candle[]>>>>; // [exchange][market][symbol][timeframe] -> Candle[]
@@ -44,10 +45,10 @@ export interface DataProviderState {
     balance: Record<string, Record<string, ExchangeBalances>>; // [accountId][walletType] -> ExchangeBalances
     ticker: Record<string, Record<string, Record<string, Ticker & { lastUpdate: number }>>>; // [exchange][market][symbol] -> Ticker with cache timestamp
   };
-  
+
   // Event system for notifying Chart widgets
   chartUpdateListeners: Record<string, ChartUpdateListener[]>; // [subscriptionKey] -> [listeners]
-  
+
   // State
   loading: boolean;
   error: string | null;
@@ -59,38 +60,38 @@ export interface DataProviderActions {
   addProvider: (provider: DataProvider) => void;
   removeProvider: (providerId: string) => void;
   setActiveProvider: (providerId: string) => void;
-  
+
   // NEW: Multiple provider management
   enableProvider: (providerId: string) => void;
   disableProvider: (providerId: string) => void;
   toggleProvider: (providerId: string) => void;
   isProviderEnabled: (providerId: string) => boolean;
   getEnabledProviders: () => DataProvider[];
-  
+
   // NEW: Advanced provider management with user integration
   createProvider: (type: 'ccxt-browser' | 'ccxt-server' | 'marketmaker.cc' | 'custom-server-with-adapter', name: string, exchanges: string[], config?: any) => DataProvider;
   updateProvider: (providerId: string, updates: { name?: string; exchanges?: string[]; priority?: number; config?: any }) => void;
   getProviderForExchange: (exchange: string) => DataProvider | null;
   getProviderExchangeMappings: (exchanges: string[]) => ProviderExchangeMapping[];
   updateProviderPriority: (providerId: string, priority: number) => void;
-  
+
   // NEW: Get symbols and markets from provider
   getSymbolsForExchange: (exchange: string, limit?: number, marketType?: string) => Promise<string[]>;
   getMarketsForExchange: (exchange: string) => Promise<string[]>;
   getAllSupportedExchanges: () => string[];
-  
+
   // NEW: Get timeframes from provider
   getTimeframesForExchange: (exchange: string) => Timeframe[];
-  
+
   // Data fetch settings management
   setDataFetchMethod: (method: DataFetchMethod) => Promise<void>;
   setRestInterval: (dataType: DataType, interval: number) => void;
-  
+
   // Deduplicated subscriptions management
-  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: { isAggregated?: boolean; tradesLimit?: number; [key: string]: any }) => Promise<ProviderOperationResult>;
+  subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
   unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
-  
+
   // Data retrieval from store
   getCandles: (exchange: string, symbol: string, timeframe?: Timeframe, market?: MarketType) => Candle[];
   getTrades: (exchange: string, symbol: string, market?: MarketType) => Trade[];
@@ -98,60 +99,60 @@ export interface DataProviderActions {
   getBalance: (accountId: string, walletType?: WalletType) => ExchangeBalances | null;
   getTicker: (exchange: string, symbol: string, market?: MarketType, maxAge?: number) => Ticker | null;
   getTickerWithRefresh: (exchange: string, symbol: string, market?: MarketType, forceRefresh?: boolean) => Promise<Ticker | null>;
-  
+
   // REST data initialization for Chart widgets
   initializeChartData: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType) => Promise<Candle[]>;
-  
+
   // REST data initialization for Trades widgets
   initializeTradesData: (exchange: string, symbol: string, market: MarketType, limit?: number, aggregated?: boolean) => Promise<Trade[]>;
-  
+
   // REST data initialization for OrderBook widgets
   initializeOrderBookData: (exchange: string, symbol: string, market: MarketType) => Promise<OrderBook>;
-  
+
   // REST data initialization for Balance widgets
   initializeBalanceData: (accountId: string, walletType: WalletType) => Promise<ExchangeBalances>;
-  
+
   // REST data initialization for Ticker widgets
   initializeTickerData: (exchange: string, symbol: string, market: MarketType) => Promise<Ticker>;
-  
+
   // Infinite scroll: Load historical candles before given timestamp
   loadHistoricalCandles: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, beforeTimestamp: number) => Promise<Candle[]>;
-  
+
   // User trading data methods
   fetchMyTrades: (accountId: string, symbol?: string, since?: number, limit?: number) => Promise<Trade[]>;
   fetchOrders: (accountId: string, symbol?: string, since?: number, limit?: number) => Promise<any[]>;
   fetchOpenOrders: (accountId: string, symbol?: string) => Promise<any[]>;
   fetchPositions: (accountId: string, symbols?: string[]) => Promise<any[]>;
-  
+
   // Central store data updates
   updateCandles: (exchange: string, symbol: string, candles: Candle[], timeframe?: Timeframe, market?: MarketType) => void;
   updateTrades: (exchange: string, symbol: string, trades: Trade[], market?: MarketType) => void;
   updateOrderBook: (exchange: string, symbol: string, orderbook: OrderBook, market?: MarketType) => void;
   updateBalance: (accountId: string, balance: ExchangeBalances, walletType?: WalletType) => void;
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
-  
+
   // Utilities
   getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
-  
+
   // Event system for Chart widgets
   addChartUpdateListener: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, listener: ChartUpdateListener) => void;
   removeChartUpdateListener: (exchange: string, symbol: string, timeframe: Timeframe, market: MarketType, listener: ChartUpdateListener) => void;
   emitChartUpdateEvent: (event: ChartUpdateEvent) => void;
-  
+
   // Internal data flow management functions
   startDataFetching: (subscriptionKey: string) => Promise<void>;
   stopDataFetching: (subscriptionKey: string) => void;
   startWebSocketFetching: (exchange: string, symbol: string, dataType: DataType, provider: DataProvider, timeframe?: Timeframe, market?: MarketType) => Promise<void>;
   startRestFetching: (exchange: string, symbol: string, dataType: DataType, provider: DataProvider, timeframe?: Timeframe, market?: MarketType) => Promise<void>;
   fetchBalance: (accountId: string, walletType?: WalletType) => Promise<void>;
-  
+
   // Intelligent CCXT method selection
   selectOptimalOrderBookMethod: (exchange: string, exchangeInstance: any) => OrderBookMethodSelection;
-  
+
   // Cleanup
   cleanup: () => void;
 }
 
 // Main store type
-export type DataProviderStore = DataProviderState & DataProviderActions; 
+export type DataProviderStore = DataProviderState & DataProviderActions;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -89,7 +89,7 @@ export interface DataProviderActions {
 
   // Deduplicated subscriptions management
   subscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: SubscriptionConfig) => Promise<ProviderOperationResult>;
-  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => void;
+  unsubscribe: (subscriberId: string, exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, config?: Pick<SubscriptionConfig, 'providerId'>) => void;
   forceCloseSubscription: (subscriptionKey: string) => void;
 
   // Data retrieval from store
@@ -132,7 +132,7 @@ export interface DataProviderActions {
   updateTicker: (exchange: string, symbol: string, ticker: Ticker, market?: MarketType) => void;
 
   // Utilities
-  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType) => string;
+  getSubscriptionKey: (exchange: string, symbol: string, dataType: DataType, timeframe?: Timeframe, market?: MarketType, providerId?: string) => string;
   getActiveSubscriptionsList: () => ActiveSubscription[];
 
   // Event system for Chart widgets

--- a/src/store/utils/webSocketUtils.ts
+++ b/src/store/utils/webSocketUtils.ts
@@ -285,7 +285,10 @@ export const createWebSocketManager = (): WebSocketConnectionManager => {
       // Закрываем все активные подписки
       for (const [id, subscription] of subscriptions) {
         if (subscription.isActive) {
-          await this.unsubscribe(id);
+          subscriptions.set(id, {
+            ...subscription,
+            isActive: false
+          });
         }
       }
       

--- a/src/types/dataProviders.ts
+++ b/src/types/dataProviders.ts
@@ -123,6 +123,7 @@ export interface CCXTBrowserConfig {
 // Configuration for CCXT Server - УПРОЩЕННАЯ ВЕРСИЯ
 export interface CCXTServerConfig {
   serverUrl: string;
+  socketUrl?: string; // Optional Socket.IO URL; defaults to serverUrl port + 1 when a port is present
   token?: string; // Authentication token for server
   timeout?: number;
   sandbox?: boolean;
@@ -255,7 +256,7 @@ export interface DataFetchSettings {
   method: DataFetchMethod;
   restIntervals: {
     trades: number; // milliseconds
-    candles: number; // milliseconds  
+    candles: number; // milliseconds
     orderbook: number; // milliseconds
     balance: number; // milliseconds
     ticker: number; // milliseconds
@@ -270,6 +271,13 @@ export interface SubscriptionKey {
   market?: MarketType; // Тип рынка (spot/futures)
 }
 
+export interface SubscriptionConfig {
+  providerId?: string; // Force a specific provider instead of auto-selection
+  isAggregated?: boolean; // для trades: использовать ли aggregate режим
+  tradesLimit?: number; // для trades: лимит количества
+  [key: string]: any; // дополнительные параметры
+}
+
 export interface ActiveSubscription {
   key: SubscriptionKey;
   subscriberCount: number;
@@ -281,15 +289,11 @@ export interface ActiveSubscription {
   wsConnection?: WebSocket; // для WebSocket соединений
   ccxtMethod?: string; // какой именно CCXT метод используется (watchOrderBook, watchBidsAsks, etc.)
   providerId?: string; // ID провайдера обслуживающего эту подписку
-  config?: {
-    isAggregated?: boolean; // для trades: использовать ли aggregate режим
-    tradesLimit?: number; // для trades: лимит количества
-    [key: string]: any; // дополнительные параметры
-  };
+  config?: SubscriptionConfig;
 }
 
 // CCXT specific types
-export type CCXTOrderBookMethod = 
+export type CCXTOrderBookMethod =
   | 'watchOrderBookForSymbols'  // Приоритет 1: diff обновления
   | 'watchOrderBook'            // Приоритет 2: полные снепшоты
   | 'fetchOrderBook';           // Fallback: REST
@@ -317,7 +321,7 @@ export interface RestCycleManager {
   subscriberIds: Set<string>;
 }
 
-// Event system for Chart widgets  
+// Event system for Chart widgets
 export type ChartUpdateEventType = 'initial_load' | 'new_candles' | 'update_last_candle' | 'full_refresh';
 
 export interface ChartUpdateEvent {
@@ -335,4 +339,4 @@ export interface ChartUpdateEvent {
   timestamp: number;
 }
 
-export type ChartUpdateListener = (event: ChartUpdateEvent) => void; 
+export type ChartUpdateListener = (event: ChartUpdateEvent) => void;


### PR DESCRIPTION
Fixes #63

## Summary
- Hardened `/api/proxy/request` validation: method allowlist, http/https-only URLs, credential rejection, private/local/metadata host blocking including IPv4-mapped IPv6, header sanitization, timeout clamping, and GET/HEAD body suppression.
- Added DNS A/AAAA validation for proxy targets, rejects public hostnames resolving to private/local/metadata IPs, pins the vetted address through the outbound lookup, and avoids automatic redirect following.
- Repaired data-provider hook/store subscription wiring so widgets use provider-scoped subscription keys, provider-specific subscriptions do not collide, auto-subscribe errors propagate through hook state, and connection status buckets are mutually exclusive.
- Fixed user trading data and CCXT server follow-ups: empty account lists clear stale trades, and anonymous CCXT server sockets resolve on connect without waiting for an auth event.
- Kept the legacy root `src` mirror consistent with `packages/client/src`.

## Verification
- `bun test` - 38 pass, 4 skipped authenticated CCXT tests
- `bun test packages/server/src/routes/proxy.test.ts`
- `bunx tsc --noEmit --pretty false` from `packages/server`
- `bunx tsc -b --pretty false` from `packages/client`
- `bunx tsc -b --pretty false` from repo root
- `bun run build`
- `bun lint` still fails with existing repo-wide lint debt: 307 problems (272 errors, 35 warnings), mainly pre-existing `no-explicit-any`, `no-case-declarations`, and hook dependency warnings. Output saved locally in `ci-logs/bun-lint.log`.

## CI Notes
- Vercel is still reporting failure on latest SHA `7f0372591fd52e06433278199b672944b75f50be` with `Authorization required to deploy` and a Vercel GitHub authorization URL for the `suenot` team. Local build and tests pass; this status requires Vercel/team authorization rather than a code change.
